### PR TITLE
Add nocode videos to docs

### DIFF
--- a/sdks/nocode/contentful.md
+++ b/sdks/nocode/contentful.md
@@ -10,7 +10,11 @@ Contentful empowers creative teams to visually craft captivating content experie
 
 ## Getting started with Contentful
 
-If you need help with getting started with Contentful, you can follow the [Contentful getting started guide](https://www.contentful.com/help/contentful-101/).
+Check out this short video to get started with your api.video integration using Contentful:
+
+<iframe src="https://embed.api.video/vod/vi6Veh495WeILYjLFbLMrUWp" type="text/html" width="100%" height="500" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>
+
+If you need more help with getting started with Contentful, you can follow the [Contentful getting started guide](https://www.contentful.com/help/contentful-101/).
 
 ## api.video Contentful plugin features
 

--- a/sdks/nocode/strapi.md
+++ b/sdks/nocode/strapi.md
@@ -6,7 +6,9 @@ meta:
 
 # Strapi
 
-With the api.video Strapi plugin you can upload and embed your videos into your Strapi website effortlessly.
+With the api.video Strapi plugin you can upload and embed your videos into your Strapi website effortlessly. Check out this short video to get started with your api.video integration using Strapi:
+
+<iframe src="https://embed.api.video/vod/vi6se2ENaM5FJFeK2yspZukC" type="text/html" width="100%" height="500" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>
 
 ## Features
 

--- a/sdks/nocode/wordpress.md
+++ b/sdks/nocode/wordpress.md
@@ -6,9 +6,11 @@ meta:
 
 # Wordpress
 
-With the api.video Wordpress plugin you can upload and embed your videos into your Wordpress website effortlessly.
+With the api.video Wordpress plugin you can upload and embed your videos into your Wordpress website effortlessly. Check out this short video to get started with your api.video integration using Wordpress:
 
-The plugin allows you to:
+<iframe src="https://embed.api.video/vod/vi7W4PZhqejbfYKxAb067toG" type="text/html" width="100%" height="500" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>
+
+The plugin enables you to:
 
 - list all of your uploaded videos
 - upload new videos
@@ -41,7 +43,7 @@ Once the plugin is installed, you'll need to configure it.
 After you've configured the api.video plugin, you can now start using it. You will noticed several button that are up for you disposal:
 
 - **Library:** Will automatically populate all of the videos in your account (if there are any existing).
-- **Add new:** will allow you to upload and add new videos to your library.
+- **Add new:** Enables you to upload and add new videos to your library.
 
 ### Uploading a video
 

--- a/sdks/nocode/zapier.md
+++ b/sdks/nocode/zapier.md
@@ -6,14 +6,18 @@ metadata:
 
 # Zapier
 
-[Zapier](https://zapier.com) is a no-code solution that allows fast integration with thousands of applications. Each automation created at Zapier is called a "Zap" and has a trigger (to kick off the automation) and an action (the thing that is done after the trigger).
+[Zapier](https://zapier.com) is a no-code solution that allows fast integration with thousands of applications. Each automation created at Zapier is called a "Zap" and has a trigger (to kick off the automation) and an action (the thing that is done after the trigger). 
+
+Watch this short video to get started with api.video integration using Zapier:
+
+<iframe src="https://embed.api.video/vod/vi19sDyBdzOFcmiS1ZuMPJkr" type="text/html" width="100%" height="500" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>
 
 {% capture content %}
-For example, a trigger might be "When a new encoding has been created at api.video" and the action would be to "share the playback link on Twitter." So now, whenever a new encoding is created, the zap will fire and automatically tweet the link to your followers.
+A trigger might be "When a new encoding has been created at api.video" and the action would be to "share the playback link on Twitter." So now, whenever a new encoding is created, the zap will fire and automatically tweet the link to your followers.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
-The api.video integration features both triggers and actions, which we will outline here:
+The api.video integration features both triggers and actions. Check out the linked pages for more details about each action and trigger.
 
 ## Triggers
 
@@ -22,19 +26,16 @@ A Zapier Trigger is an event that kicks off an automation process. There are 5 T
 
 ### Non instant:
 
-- New Video Created: A new videoId has been created.
-- New Live Stream Created: A new LiveStreamId has been created.
+- New [Video Created](/sdks/nocode/video-created): A new videoId has been created.
+- New [Live Stream Created](/sdks/nocode/live-stream-created): A new LiveStreamId has been created.
 
 ### Instant
 
-- Live stream started: The live stream _broadcast_ has started.
-- Live stream ended: The live stream _broadcast_ has ended.
-- Video encoding completed: Triggers when a specified encoding (based on size of the video) has been encoded and is ready to play.
-- All live events: Three triggers in one endpoint: broadcast started, stopped and when the specified recording is ready for playback.
+- [Live stream started](/sdks/nocode/live-stream-started): The live stream _broadcast_ has started.
+- [Live stream ended](/sdks/nocode/live-stream-ended): The live stream _broadcast_ has ended.
+- [Video encoding completed](/sdks/nocode/video-encoding-completed): Triggers when a specified encoding (based on size of the video) has been encoded and is ready to play.
+- [All live events](/sdks/nocode/all-live-events): Three triggers in one endpoint: broadcast started, stopped and when the specified recording is ready for playback.
 
 ## Actions
 
-- Create Video: Will create a video at api.video when triggered.
-
-The following pages will describe each of the Zapier triggers and actions in greater detail.
-
+- [Create Video](/sdks/nocode/create-video): Will create a video at api.video when triggered.


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1206048315667454).

**Summary**

- Added available getting started videos ([Notion](https://www.notion.so/apivideo/No-code-integrations-e1b7bd3ca0064961a2b44562bc42674d)) to the [no-code integration guides](https://docs.api.video/sdks/nocode)
- Updated the Zapier guide with internal links
- fixed some wording issues