### PR TITLE
Add information about rate limiting

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -60,6 +60,30 @@ Follow these best practices to secure your API keys:
 
 ## Limitation
 
+api.video limits the number of accepted API requests **per minute**. The limitation that the API applies to your calls depends on these factors:
+
+* the [API environment](https://docs.api.video/reference#environments) you send your calls in
+* your [pricing plan](https://api.video/pricing)
+* the request method that your calls use
+
+|         | Sandbox | Production |
+| ------- | ------- | ---------- |
+| Uploads | 40      | 100        |
+| Writes  | 40      | 200        |
+| Reads   | 100     | 500        |
+
+The API returns information about the applied rate limits in the header of every response. Check these header elements:
+
+- `X-RateLimit-Limit` shows the applied request limit per minute.
+- `X-RateLimit-Remaining` shows the number of available requests you have left for the current time window.
+- `X-RateLimit-Retry-After` shows the number of seconds left until the current rate limit window resets.
+
+api.video recommends that you implement a retry method in your app that responds to the `429 - Too many requests` error. You can scale down your request volume and return the failed, rate limited requests to your queue to wait according to the value of `X-RateLimit-Retry-After`.
+
+If you want to increase the limits that apply to your calls get in touch with the support team via the chat box.
+
+### Video upload
+
 Video upload (VOD) is limited in size and minutes. We support upload for videos that are:
 
 - at most 30 GiB in size.

--- a/reference/general-errors.md
+++ b/reference/general-errors.md
@@ -16,4 +16,5 @@ meta:
 | `The requested resource could not be found.`       | `404`  | You requested a resource (video, live stream, etc.) that doesn't exist at all or that doesn't belong to your project. |         |
 | `Unrecognized request URL.`                        | `404`  | You send a request to an endpoint that doesn't exist at all, for example GET /foobar.                                 |         |
 | `Method is not allowed for this route.`            | `405`  | The endpoint exists but not for this HTTP method, for example you DELETE /webhooks instead of GET.                    |         |
+| `Too many requests.`                               | `429`  | You sent too many requests and exceeded the API rate limit.                                                           |         |
 | `Server error`                                     | `500`  | An error occurred on our server, we are working to fix it.                                                            |         |

--- a/reference/too-many-requests.md
+++ b/reference/too-many-requests.md
@@ -1,0 +1,21 @@
+---
+title: Too many requests
+meta: 
+    description: This guide explains the cause and the possible solutions for the Too many requests error.
+---
+
+# Too many requests
+
+You sent too many requests and exceeded the API rate limit.
+
+## Solution
+
+The API returns information about the applied rate limits in the header of every response. Check these header elements:
+
+- `X-RateLimit-Limit` shows the applied request limit per minute.
+- `X-RateLimit-Remaining` shows the number of available requests you have left for the current time window.
+- `X-RateLimit-Retry-After` shows the number of seconds left until the current rate limit window resets.
+
+api.video recommends that you implement a retry method in your app that responds to the `429 - Too many requests` error. You can scale down your request volume and return the failed, rate limited requests to your queue to wait according to the value of `X-RateLimit-Retry-After`.
+
+Read more about API rate limits in the [API reference](https://docs.api.video/reference#limitation) or get in touch via the chat box if you want to increase the limits that apply to your calls.


### PR DESCRIPTION
⚠️ **This PR should not be merged before API rate limiting is released** ⚠️

Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1207037975949562).

Docs drafts are [here](https://www.notion.so/apivideo/API-rate-limiting-2ef948077a3748298c34be56a254578e).

**Summary**

* added information about API rate limiting to the API reference's [Limitation](https://docs.api.video/reference#limitation) section
* added the 429 - Too many requests error to [General errors](https://docs.api.video/reference/general-errors) as a sub-page (the API will point to this page in the error response's `type` field)

⚠️ **This PR should not be merged before API rate limiting is released** ⚠️