### PR TITLE
Remove font size override

### DIFF
--- a/_assets/css/style.css
+++ b/_assets/css/style.css
@@ -396,10 +396,6 @@
   font-weight: 500 !important;
 }
 
-p {
-  font-size: 18px;
-}
-
 .dark p {
   color: rgba(255, 255, 255, 0.70);
 }


### PR DESCRIPTION
Quick fix to remove a font-size override that was left over from the previous docs version.