### PR TITLE
Remove v2 and migration paragraph

### DIFF
--- a/delivery-analytics/analytics.md
+++ b/delivery-analytics/analytics.md
@@ -1,12 +1,12 @@
 ---
-title: Analytics v2.0
+title: Analytics
 meta: 
   description: Learn how you can get data insights for your videos and live streams using api.video's Analytics solution.
 ---
 
-# Analytics v2.0
+# Analytics
 
-api.video's Analytics v2.0 enables you to retrieve complex event data about your videos and live streams.
+api.video's Analytics enables you to retrieve complex event data about your videos and live streams.
 
 For example, you can:
 
@@ -16,11 +16,11 @@ For example, you can:
 
 Use this data to understand your audience, or integrate the data directly into your own application to display it to your viewers.
 
-Visit the **[Analytics](https://dashboard.api.video/data)** page on the Dashboard to get started and see your data visualized, or jump into the **[API reference](/reference/api/Analytics-v2)** and see how you can work with the data through our API!
+Visit the **[Analytics](https://dashboard.api.video/data)** page on the Dashboard to get started and see your data visualized, or jump into the **[API reference](/reference/api/Analytics)** and see how you can work with the data through our API!
 
 ## How it works
 
-Analytics v2.0 uses player events to analyze and segment your viewers' interactions with your content. Here are some key acpects that can help you ensure that your Analytics v2.0 implementation runs smoothly:
+Analytics uses player events to analyze and segment your viewers' interactions with your content. Here are some key acpects that can help you ensure that your Analytics implementation runs smoothly:
 
 - Player events are generated when your viewers engage with a video or live stream session.
 - Data is refreshed in real time, with a frequency of `<5s`.
@@ -34,22 +34,22 @@ After player events are collected, there is a short delay while the API processe
 ### Requirements
 
 <Callout pad="2" type="info">
-The Analytics v2.0 features are available using api.video's video player. Check out the [Video Player SDK](/sdks/player/apivideo-player-sdk) for details about the implementation.
+The Analytics features are available using api.video's video player. Check out the [Video Player SDK](/sdks/player/apivideo-player-sdk) for details about the implementation.
 </Callout>
 
 ## How to use
 
-Analytics v2.0 offers 3 dedicated API endpoints that you can use to programmatically retrieve data about your content:
+api.video offers 3 dedicated API endpoints that you can use to programmatically retrieve data about your content:
 
 | Endpoint                                                                                 | Usage                                         |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------- |
-| [`/data/metrics/{metric}/{aggregation}`](/reference/api/Analytics-v2#retrieve-aggregated-metrics) | Retrieve aggregated metrics                   |
-| [`/data/buckets/{metric}/{breakdown}`](/reference/api/Analytics-v2#retrieve-metrics-in-a-breakdown-of-dimensions)   | Retrieve metrics in a breakdown of dimensions |
-| [`/data/timeseries/{metric}`](/reference/api/Analytics-v2#retrieve-metrics-over-time)            | Retrieve metrics over time                    |
+| [`/data/metrics/{metric}/{aggregation}`](/reference/api/Analytics#retrieve-aggregated-metrics) | Retrieve aggregated metrics                   |
+| [`/data/buckets/{metric}/{breakdown}`](/reference/api/Analytics#retrieve-metrics-in-a-breakdown-of-dimensions)   | Retrieve metrics in a breakdown of dimensions |
+| [`/data/timeseries/{metric}`](/reference/api/Analytics#retrieve-metrics-over-time)            | Retrieve metrics over time                    |
 
-Visit the **[API reference](/reference/api/Analytics-v2)** for details on how you can interact with the Analytics v2.0 API, including request parameters and sample responses.
+Visit the **[API reference](/reference/api/Analytics)** for details on how you can interact with the Analytics API, including request parameters and sample responses.
 
-Here are some real-world questions where metrics and dimensions from Analytics v2.0 can help you find the answers:
+Here are some real-world questions where metrics and dimensions from Analytics can help you find the answers:
 
 - E-learning
     - *How many students have played my courses?* → `play`
@@ -66,34 +66,11 @@ Here are some real-world questions where metrics and dimensions from Analytics v
 <Callout pad="2" type="info">
 **Testing**
 
-You can test the Analytics v2.0 endpoints **in api.video's sandbox environment**. Check out [Environments](/reference#environments) for more details. The sandbox environment returns data from the last 24 hours.
+You can test the Analytics endpoints **in api.video's sandbox environment**. Check out [Environments](/reference#environments) for more details. The sandbox environment returns data from the last 24 hours.
 </Callout>
-
-## Migrating from the Analytics v1 API
-
-Migrating to the Analytics v2.0 API is simple. Analytics v1 only provided 2 endpoints, which returned play event count for videos and live streams. In Analytics v2.0, endpoints are no longer separated for videos and live streams.
-
-### Endpoint mapping
-
-| Analytics v1 endpoints          | Usage                                             |
-| ------------------------------- | --------------------------------------------------|
-| `/analytics/videos/plays`       | to get the number of play events for videos       |
-| `/analytics/live-streams/plays` | to get the number of play events for live streams |
-
-Analytics v1's `/play` metric can be directly mapped to 3 new endpoints:
-
-- For the number of play events, use `/data/metrics/{metric}/{aggregation}` with the `play` metric and `count` aggregation.
-    - Example: `/data/metrics/play/count`
-
-- For the number of play events in a breakdown by dimensions, use `/data/buckets/{metric}/{breakdown}` with the `play` metric and one of these dimensions:
-        - `media-id`, `media-type`, `continent`, `country`, `device-type`, `operating-system`, `browser`,
-    - Example: `/data/buckets/play/country`
-
-- For the number of play events over time, use `/data/timeseries/{metric}` with the `play` metric.
-    - Example: `/data/timeseries/play`
 
 ## What's next
 
-Check out the **[API reference](/reference/api/Analytics-v2)** for sample responses and errors, and more details about using the Analytics endpoints.
+Check out the **[API reference](/reference/api/Analytics)** for sample responses and errors, and more details about using the Analytics endpoints.
 
 If you have any questions, reach out to the team using the chatbox!

--- a/doctave.yaml
+++ b/doctave.yaml
@@ -182,7 +182,7 @@ redirects:
   - from: /docs/zapier
     to: /sdks/nocode/zapier
   - from: /reference/analytics
-    to: /reference/api/Analytics-v2
+    to: /reference/api/Analytics
   - from: /reference/apivideo-api-reference
     to: /reference
   - from: /reference/authentication
@@ -198,9 +198,9 @@ redirects:
   - from: /reference/delete-webhook
     to: /reference/api/Webhooks#delete-a-webhook
   - from: /reference/get_analytics-live-streams-plays
-    to: /reference/api/Analytics-v2
+    to: /reference/api/Analytics
   - from: /reference/get_analytics-videos-plays
-    to: /reference/api/Analytics-v2
+    to: /reference/api/Analytics
   - from: /reference/get_live-streams
     to: /reference/api/Live-Streams#list-all-live-streams
   - from: /reference/get_live-streams-livestreamid
@@ -358,7 +358,7 @@ redirects:
   - from: /recipes/consume-private-videos-with-videojs
     to: /
   - from: /reference/analytics-1
-    to: /reference/api/Analytics-v2
+    to: /reference/api/Analytics
   - from: /reference/delete_live-streams-livestreamid
     to: /reference/api/Live-Streams#delete-a-live-stream
   - from: /reference/delete_live-streams-livestreamid-thumbnail

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11563,7 +11563,7 @@ paths:
   '/data/metrics/{metric}/{aggregation}':
     get:
       tags:
-      - Analytics v2
+      - Analytics
       summary: Retrieve aggregated metrics
       description: Retrieve time-based and countable metrics like average watch time or the number of impressions over a certain period of time.
       operationId: GET_aggregated-metrics
@@ -11790,7 +11790,7 @@ paths:
   '/data/buckets/{metric}/{breakdown}':
     get:
       tags:
-      - Analytics v2
+      - Analytics
       summary: Retrieve metrics in a breakdown of dimensions
       description: Retrieve detailed analytics play-rate and number of impressions segmented by dimensions like country or device type.
       operationId: GET_metrics-breakdown
@@ -12033,7 +12033,7 @@ paths:
   '/data/timeseries/{metric}':
     get:
       tags:
-      - Analytics v2
+      - Analytics
       summary: Retrieve metrics over time
       description: Retrieve countable metrics like the number of plays or impressions, grouped by the time at which they occurred
       operationId: GET_metrics-over-time
@@ -14545,7 +14545,7 @@ components:
           description: The name of the parameter that caused the error.
           type: string
     analytics-aggregated-metrics-response:
-      title: Analytics v2.0 response for aggregated metrics
+      title: Analytics response for aggregated metrics
       type: object
       properties:
         context:
@@ -14594,7 +14594,7 @@ components:
       - context
       - data
     analytics-metrics-breakdown-response:
-      title: Analytics v2.0 response for metrics breakdown by dimension
+      title: Analytics response for metrics breakdown by dimension
       type: object
       properties:
         context:
@@ -14656,7 +14656,7 @@ components:
       - data
       - pagination
     analytics-metrics-over-time-response:
-      title: Analytics v2.0 response for metrics over time
+      title: Analytics response for metrics over time
       type: object
       properties:
         context:

--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -55,7 +55,7 @@
   items:
     - open_api_spec: openapi.yaml
       only:
-        - Analytics v2
+        - Analytics
 
 - heading: Webhooks
   items:


### PR DESCRIPTION
Context: https://api-video.slack.com/archives/C01HRNQKC2K/p1720184092960169?thread_ts=1720182120.585669&cid=C01HRNQKC2K

**Summary**

- remove mentions of `v2` in the context of Analytics
- remove paragraph about migrating from v1 to v2 for Analytics