### PR TITLE
Add new error pages and fix URLs

### DIFF
--- a/doctave.yaml
+++ b/doctave.yaml
@@ -415,3 +415,15 @@ redirects:
     to: /reference/errors
   - from: /reference/internal-server-error
     to: /reference/general-errors
+  - from: /docs/authenticationinvalid_credentials
+    to: /reference/authentication-invalid-user-credentials
+  - from: /docs/attributerequired
+    to: /reference/attribute-required
+  - from: /docs/filealreadyuploaded
+    to: /reference/video-source-already-uploaded
+  - from: /docs/filemissing
+    to: /reference/uploaded-file-no-file
+  - from: /docs/multiplefilesuploaded
+    to: /reference/uploaded-file-multiple-files
+  - from: /docs/fileextension
+    to: /reference/uploaded-file-extension-invalid

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,7 +50,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/authenticationinvalid_credentials'
+                    type: 'https://docs.api.video/reference/authentication-invalid-user-credentials'
                     title: The user credentials were incorrect.
                     name: ''
                     status: 400
@@ -126,7 +126,7 @@ paths:
                 response:
                   value:
                     status: 400
-                    type: 'https://docs.api.video/docs/authenticationinvalid_credentials'
+                    type: 'https://docs.api.video/reference/authentication-invalid-user-credentials'
                     title: The user credentials were incorrect.
                     name: ''
       x-client-action: refresh
@@ -618,21 +618,21 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/attributerequired'
+                    type: 'https://docs.api.video/reference/attribute-required'
                     title: This attribute is required.
                     name: title
                     status: 400
                     problems:
-                      - type: 'https://docs.api.video/docs/attributerequired'
+                      - type: 'https://docs.api.video/reference/attribute-required'
                         title: This attribute is required.
                         name: title
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be a ISO8601 date.
                         name: scheduledAt
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
                         name: tags
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
                         name: metadata
         '429':
@@ -1010,21 +1010,21 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/filealreadyuploaded'
+                    type: 'https://docs.api.video/reference/video-source-already-uploaded'
                     title: The source of the video is already uploaded.
                     name: file
                     status: 400
                     problems:
-                      - type: 'https://docs.api.video/docs/filealreadyuploaded'
+                      - type: 'https://docs.api.video/reference/video-source-already-uploaded'
                         title: The source of the video is already uploaded.
                         name: file
-                      - type: 'https://docs.api.video/docs/filealreadyuploaded'
+                      - type: 'https://docs.api.video/reference/video-source-already-uploaded'
                         title: The video xxxx has already been uploaded.
                         name: video
-                      - type: 'https://docs.api.video/docs/filemissing'
+                      - type: 'https://docs.api.video/reference/uploaded-file-no-file'
                         title: There is no uploaded file in the request.
                         name: file
-                      - type: 'https://docs.api.video/docs/multiplefilesuploaded'
+                      - type: 'https://docs.api.video/reference/uploaded-file-multiple-files'
                         title: There is more than one uploaded file in the request.
                         name: file
         '404':
@@ -1049,7 +1049,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -1352,7 +1352,7 @@ paths:
                 response:
                   value:
                     status: 400
-                    type: 'https://docs.api.video/docs/fileextension'
+                    type: 'https://docs.api.video/reference/uploaded-file-extension-invalid'
                     title: 'Only [jpeg, jpg, JPG, JPEG, png, PNG] extensions are supported.'
                     name: file
         '429':
@@ -1812,7 +1812,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: watermarkId
                     status: 404
@@ -1996,7 +1996,7 @@ paths:
                 response:
                   value:
                     status: 400
-                    type: 'https://docs.api.video/docs/fileextension'
+                    type: 'https://docs.api.video/reference/uploaded-file-extension-invalid'
                     title: 'Only [jpeg, jpg, JPG, JPEG] extensions are supported.'
                     name: file
         '404':
@@ -2021,7 +2021,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -2322,7 +2322,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -2622,7 +2622,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -2866,7 +2866,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -3136,18 +3136,18 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/attributeinvalid'
+                    type: 'https://docs.api.video/reference/invalid-attribute'
                     title: This attribute must be a ISO-8601 date.
                     name: scheduledAt
                     status: 400
                     problems:
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be a ISO-8601 date.
                         name: scheduledAt
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
                         name: tags
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
                         name: metadata
         '404':
@@ -3172,7 +3172,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -3515,7 +3515,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
@@ -6479,7 +6479,7 @@ paths:
                 response:
                   value:
                     status: 400
-                    type: 'https://docs.api.video/docs/fileextension'
+                    type: 'https://docs.api.video/reference/uploaded-file-extension-invalid'
                     title: 'Only [jpeg, jpg, JPG, JPEG] extensions are supported.'
                     name: file
         '404':
@@ -6504,7 +6504,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: liveStreamId
                     status: 404
@@ -6762,7 +6762,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: liveStreamId
                     status: 404
@@ -10275,7 +10275,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: playerId
                     status: 404
@@ -10512,7 +10512,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: playerId
                     status: 404
@@ -10774,7 +10774,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: playerId
                     status: 404
@@ -11097,7 +11097,7 @@ paths:
                 response:
                   value:
                     status: 400
-                    type: 'https://docs.api.video/docs/fileextension'
+                    type: 'https://docs.api.video/reference/uploaded-file-extension-invalid'
                     title: 'Only [''jpg'', ''JPG'', ''jpeg'', ''JPEG'', ''png'', ''PNG''] extensions are supported.'
                     name: file
         '404':
@@ -11122,7 +11122,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: playerId
                     status: 404
@@ -11385,7 +11385,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: playerId
                     status: 404
@@ -12601,18 +12601,18 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/attributerequired'
+                    type: 'https://docs.api.video/reference/attribute-required'
                     events: This attribute is required.
                     name: events
                     status: 400
                     problems:
-                      - type: 'https://docs.api.video/docs/attributerequired'
+                      - type: 'https://docs.api.video/reference/attribute-required'
                         title: This attribute is required.
                         name: events
-                      - type: 'https://docs.api.video/docs/attributerequired'
+                      - type: 'https://docs.api.video/reference/attribute-required'
                         title: This attribute is required.
                         name: url
-                      - type: 'https://docs.api.video/docs/attributeinvalid'
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
                         name: events
         '429':
@@ -13094,7 +13094,7 @@ paths:
               examples:
                 response:
                   value:
-                    type: 'https://docs.api.video/docs/resourcenot_found'
+                    type: 'https://docs.api.video/reference/resource-not-found'
                     title: The requested resource was not found.
                     name: webhookId
                     status: 404

--- a/reference/attribute-required.md
+++ b/reference/attribute-required.md
@@ -1,0 +1,31 @@
+---
+title: Attribute required
+meta: 
+    description: This guide explains the cause and the possible solutions for the Attribute required error.
+---
+
+# Attribute required
+
+Your request was missing an attribute that is required by the API.
+
+## Solution
+
+If you're not using one of our API clients, check our documentation for the endpoint you're using and make sure the attributes are set up correctly in your request.
+
+If you are using one of our API clients, check the rules for how to format attributes within your client. They are not always identical to how they would be sent if you weren't using an API client.  
+
+## Learning resources
+
+### Tools
+
+You can cut down on mistakes by using one of our clients. We offer clients for our API in these languages:
+
+- [NodeJS](../sdks/api-clients/apivideo-nodejs-client.md)
+- [Python](../sdks/api-clients/apivideo-python-client.md)
+- [PHP](../sdks/api-clients/apivideo-php-client.md)
+- [Go](../sdks/api-clients/apivideo-go-client.md)
+- [C#](../sdks/api-clients/apivideo-csharp-client.md)
+- [Java](../sdks/api-clients/apivideo-java-client.md)
+- [Swift](../sdks/api-clients/apivideo-swift5-client.md)
+- [Android](../sdks/api-clients/apivideo-android-client.md)
+

--- a/reference/authentication-invalid-upload-token.md
+++ b/reference/authentication-invalid-upload-token.md
@@ -10,8 +10,6 @@ The upload token you use does not exist at all or has expired.
 
 ## Solution
 
-tauri://localhost#generate-an-upload-token
-
 You create upload tokens with the [delegated upload](/reference/api/Upload-Tokens#generate-an-upload-token) endpoint. If you don't specify how long they last, they last until you delete them. If you are having a problem with your token, you may have the token represented incorrectly or you may have created a token that expired. To fetch a new one, you'll need an authentication token, or a refresh token which you can use to retrieve a new authentication token.
 
 ## Learning resources

--- a/reference/authentication-invalid-user-credentials.md
+++ b/reference/authentication-invalid-user-credentials.md
@@ -1,0 +1,35 @@
+---
+title: Invalid user credentials
+meta: 
+    description: This guide explains the cause and the possible solutions for the Invalid user credentials error.
+---
+
+# Invalid user credentials
+
+The API key or the refresh token you sent may be invalid.
+
+## Solution
+
+Check if the API key you use is correct or not. You can generate new API keys in the [dashboard](https://dashboard.api.video/project-settings/api-keys).
+
+Check if your refresh token is correct or not. You can fetch a new token using the [Authenticate](/reference/api/Advanced-authentication#get-bearer-token) endpoint.
+
+## Learning resources
+
+### Tutorials
+
+- [Authentication steps](https://api.video/blog/tutorials/authentication-tutorial/) \- Walk through how to authenticate and retrieve an access token.
+- [When your token expires, hit refresh and protect your API key](https://api.video/blog/tutorials/when-your-token-expires-hit-refresh-and-protect-your-api-key/) \- Use refresh tokens to retrieve a new access token when yours expires.
+
+### Tools
+
+You can cut down on mistakes by using one of our clients. We offer clients for our API in these languages:
+
+- [NodeJS](../sdks/api-clients/apivideo-nodejs-client.md)
+- [Python](../sdks/api-clients/apivideo-python-client.md)
+- [PHP](../sdks/api-clients/apivideo-php-client.md)
+- [Go](../sdks/api-clients/apivideo-go-client.md)
+- [C#](../sdks/api-clients/apivideo-csharp-client.md)
+- [Java](../sdks/api-clients/apivideo-java-client.md)
+- [Swift](../sdks/api-clients/apivideo-swift5-client.md)
+- [Android](../sdks/api-clients/apivideo-android-client.md)

--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -77,6 +77,8 @@
           href: ./authentication-invalid-upload-token.md
         - label: Invalid Refresh Token
           href: ./authentication-invalid-refresh-token.md
+        - label: Invalid User Credentials
+          href: ./authentication-invalid-user-credentials.md
         - label: Invalid Authorization Header Value
           href: ./authentication-invalid-authorization-header-value.md
         - label: Missing Authorization Header
@@ -91,10 +93,14 @@
       items:
         - label: Invalid Attribute
           href: ./invalid-attribute.md
+        - label: Attribute Required
+          href: ./attribute-required.md
         - label: Invalid Query Parameter
           href: ./invalid-query-parameter.md
         - label: Invalid Payload
           href: ./invalid-payload.md
+        - label: Invalid File Extension
+          href: ./uploaded-file-extension-invalid.md
         - label: Method Not Allowed
           href: ./method-not-allowed.md
         - label: Resource Not Found

--- a/reference/uploaded-file-extension-invalid.md
+++ b/reference/uploaded-file-extension-invalid.md
@@ -1,0 +1,13 @@
+---
+title: Uploaded File Extension Invalid
+meta: 
+    description: This guide explains the cause and the possible solutions for the Uploaded File Extension Invalid error.
+---
+
+# Uploaded File Extension Invalid
+
+The file you uploaded has a mime type or file extension that the API does not accept. This can occur for example when you [upload thumbnails to a video](/reference/api/Videos#upload-a-thumbnail), or a [logo for your player](/reference/api/Player-Themes#upload-a-logo).
+
+## Solution
+
+Check the API's response to your request, as it contains the accepted file extensions. Update the file in your request to comply with the requirements.


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1207795160247631).

**Summary**

- the OpenAPI specification still had some old links in the ReadMe path format. I added redirects from all old URLs to the new ones: from `docs.api.video/docs/*` to `docs.api.video/reference/*`. 
- in some cases, there was no content that could be directly mapped, so I created these error pages:
   -  `reference/attribute-required.md`
   -  `reference/uploaded-file-extension-invalid.md`
   -  `reference/authentication-invalid-user-credentials.md`
   
   
@ThibaultBee after a discussion with @olivierapivideo , I am making this change directly on the OpenAPI spec in the `documentation` repo. Olivier will move all changes to the client-generator repo to avoid a bunch of conflicts. ⚠️ 