### PR TITLE
Update Analytics docs

### DIFF
--- a/delivery-analytics/analytics.md
+++ b/delivery-analytics/analytics.md
@@ -20,7 +20,7 @@ Visit the **[Analytics](https://dashboard.api.video/data)** page on the Dashboar
 
 ## How it works
 
-Analytics uses player events to analyze and segment your viewers' interactions with your content. Here are some key acpects that can help you ensure that your Analytics implementation runs smoothly:
+Analytics uses player events to analyze and segment your viewers' interactions with your content. Here are some key aspects that can help you ensure that your Analytics implementation runs smoothly:
 
 - Player events are generated when your viewers engage with a video or live stream session.
 - Data is refreshed in real time, with a frequency of `<5s`.
@@ -28,8 +28,6 @@ Analytics uses player events to analyze and segment your viewers' interactions w
 - Data does not carry over from the previous version of Analytics.
 - Video re-plays using the dedicated re-play button in the player do not generate player events.
 - If a user is viewing your content via a browser, refreshes the tab, and plays the content again, a new event is generated.
-
-After player events are collected, there is a short delay while the API processes the data. api.video recommends that you retrieve analytics periodically, for example once every 15 minutes. This enables you to keep track of user engagement or manage user-generated content without delay.
 
 ### Requirements
 
@@ -58,6 +56,7 @@ Here are some real-world questions where metrics and dimensions from Analytics c
     
 - Short-form videos
     - *Have my viewers watched the first N videos on the feed until the end?* → `end`
+    - *How many times have my viewers watched a specific video?* → `play-total` + `media-id`
     
 - Advertising
     - *How many impressions have my ads generated?*  → `impression`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11802,6 +11802,7 @@ paths:
 
           - `play` is the number of times your content has been played.
           - `play-rate` is the ratio that calculates the number of plays your content receives divided by its impressions.
+          - `play-total` is the total number of times a specific content has been played. You can only use the `media-id` breakdown with this metric.
           - `start` is the number of times playback was started.
           - `end` is the number of times playback has ended with the content watch until the end.
           - `impression` is the number of times your content has been loaded and was ready for playback.
@@ -11813,6 +11814,7 @@ paths:
           enum: 
             - play
             - play-rate
+            - play-total
             - start
             - end
             - impression


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1207795165508758).

**Summary**

- Added the `/data/buckets/play-total/media-id` route to the `/data/buckets/{metric}/{breakdown}` endpoint
- Added a use case example for `play-total` + `media-id`

Also incorporated changes from  Guillaume’s feedback here: [Analytics docs feedbacks](https://www.notion.so/Analytics-docs-api-video-feedbacks-8888607108534cf38f440d5bccf22ec1?pvs=21)

- removed unnecessary paragraph
- fixed typo

**Not part of this PR**

Started vote on moving Analytics docs to a standalone tab: https://api-video.slack.com/archives/C01HRNQKC2K/p1721056171869069

- this will be done in a separate PR ⚠️