### PR TITLE
Remove beta mentions from SRT

### DIFF
--- a/live-streaming/create-a-live-stream.md
+++ b/live-streaming/create-a-live-stream.md
@@ -14,8 +14,6 @@ This guide helps you follow along with the video and learn how to set up your li
 
 <Callout pad="2" type="info">
 api.video supports both `RTMP` and `SRT` protocols for live streaming.
-
-Accepting live streams through `SRT` **is currently in beta** - reach out if you have any questions or encounter any issues!
 </Callout>
 
 ## API reference

--- a/live-streaming/live-stream-best-practices.md
+++ b/live-streaming/live-stream-best-practices.md
@@ -13,10 +13,6 @@ meta:
 - In order to prevent the live stream from getting stuck (buffering indefinitely), please ensure that you are following the recommended [settings](#recommended-setting-for-ingestion).
 - Make sure to verify that the connection speed is adequate and stable before the stream is starting.
 
-## Streaming protocols
-
-api.video supports both `RTMP` and `SRT` protocols for live streaming. Accepting live streams through `SRT` **is currently in beta** - reach out if you have any questions or encounter any issues!
-
 ### SRT details
 
 * The minimum accepted value for `latency` is 120 ms, lower values will be ignored.
@@ -44,12 +40,16 @@ When reaching the end of the playback, the player buffers until the live stream 
 
 Reconnection is handled by api.video, however, an edge case might occur (very slim chance), which will result in the inability to reconnect to the stream with good quality. In this case, we recommend creating a manual stream reconnection, where the streamer will create a new streaming key while the consumers will have to refresh their player instance.
 
+## Streaming protocols
+
+api.video supports both `RTMP` and `SRT` protocols for live streaming. 
+
 ## Streaming servers
 
 | Protocol | Description                                | Server URL                                             |
 | -------- | ------------------------------------------ | ------------------------------------------------------ |
 | `RTMP`   | The default streaming server.              | `rtmp://broadcast.api.video/s`                         |
-| `SRT`    | The `SRT` server, currently **in beta**.   | `srt://broadcast.api.video:6200?streamid={stream_key}` |
+| `SRT`    | The `SRT` server.   | `srt://broadcast.api.video:6200?streamid={stream_key}` |
 
 ## Recommended setting for ingestion
 


### PR DESCRIPTION
Context: https://api-video.slack.com/archives/C02CW29KJ/p1721146667846479

**Summary**

I removed mentions of "beta" where we talk about the SRT protocol.