### PR TITLE
Add redirect to analytics page

### DIFF
--- a/doctave.yaml
+++ b/doctave.yaml
@@ -419,6 +419,8 @@ redirects:
     to: /delivery/ads
   - from: /delivery-analytics/analytics
     to: /analytics/overview
+  - from: /docs/analytics
+    to: /analytics
   - from: /delivery-analytics/delivery-analytics-quickstart
     to: /delivery/quickstart
   - from: /delivery-analytics/domain-referrer


### PR DESCRIPTION
Context on [Slack](https://api-video.slack.com/archives/C01L45802S2/p1721394234918299).

I added a missing redirect from the old ReadMe path format to the new Analytics landing page in the docs. This fixes a possible `404`.