### PR TITLE
Update restream protocol limitations

### DIFF
--- a/live-streaming/restreams.md
+++ b/live-streaming/restreams.md
@@ -57,9 +57,9 @@ api.video currently supports `RTMPS` and `RTMP` restreaming destinations. Provid
 - Instagram
 - Twitch
 - LinkedIn
-- Instagram (through [YellowDuck](https://yellowduck.tv/))
+- Instagram
 
-Providers that use SRT or any other protocol (like Kick or Telegram) are currently not supported.
+Providers that use SRT or any other protocol are currently not supported for restreaming.
 
 ## Getting Started
 


### PR DESCRIPTION
Context [on Slack](https://api-video.slack.com/archives/C01HRNQKC2K/p1722436793677859?thread_ts=1722435483.516609&cid=C01HRNQKC2K).

Removed limitations of restreaming to destinations that only accept RTMPS.