### PR TITLE
Add Video Restore feature to docs

### DIFF
--- a/live-streaming/list-live-streams.md
+++ b/live-streaming/list-live-streams.md
@@ -161,7 +161,7 @@ You can send in a request to filter based on the different parameters for a live
 
 - `streamKey` - A string representing the stream key that allows you to stream videos to a specific live stream container
 - `name` - A string representing the name of your live stream 
-- `sortBy` - A string indicating how you want the results sorted, options include createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time-based options, the time is presented in ISO-8601 format.
+- `sortBy` - A string indicating how you want the results sorted, options include createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time-based options, the time is presented in ATOM UTC format.
 - `sortOrder` - A string indicating the order in which to sort everything. Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that latter values precede earlier ones. The title is 0-9 and A-Z ascending and Z-A, 9-0 descending.
 - `currentPage` - Choose the search results page to return—minimum value: 1.
 - `pageSize` - Choose the number of results per page. Allowed values: 1-100, default is 25.
@@ -192,7 +192,7 @@ func main() {
     
     req.StreamKey("30087931-229e-42cf-b5f9-e91bcc1f7332") // string | The unique stream key that allows you to stream videos.
     req.Name("My Video") // string | You can filter live streams by their name or a part of their name.
-    req.SortBy("createdAt") // string | Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
+    req.SortBy("createdAt") // string | Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ATOM UTC format.
     req.SortOrder("desc") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
     req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)
     req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)
@@ -238,7 +238,7 @@ const ApiVideoClient = require('@api.video/nodejs-client');
 
         const streamKey = '30087931-229e-42cf-b5f9-e91bcc1f7332'; // The unique stream key that allows you to stream videos.
         const name = 'My Video'; // You can filter live streams by their name or a part of their name.
-        const sortBy = 'createdAt'; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
+        const sortBy = 'createdAt'; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ATOM UTC format.
         const sortOrder = 'desc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
         const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
         const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -293,6 +293,9 @@ paths:
                             value: Tutorial
                         publishedAt: '2019-12-16T08:25:51.000Z'
                         updatedAt: '2019-12-16T08:48:49.000Z'
+                        removed: false
+                        removedAt: null
+                        deletesAt: null
                         source:
                           uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
                         assets:
@@ -319,6 +322,9 @@ paths:
                             value: Computers
                         publishedAt: '2019-12-16T08:25:51.000Z'
                         updatedAt: '2019-12-16T08:48:49.000Z'
+                        removed: false
+                        removedAt: null
+                        deletesAt: null
                         source:
                           uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                         assets:
@@ -342,6 +348,9 @@ paths:
                             value: Short
                         publishedAt: '2019-12-16T08:25:51.000Z'
                         updatedAt: '2019-12-16T08:48:49.000Z'
+                        removed: false
+                        removedAt: null
+                        deletesAt: null
                         source:
                           uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                         assets:
@@ -577,6 +586,9 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '4665-07-14T23:36:18.598Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -988,6 +1000,9 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '4665-07-14T23:36:18.598Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -1973,6 +1988,9 @@ paths:
                         value: Tutorial
                     createdAt: '2020-03-03T12:52:03.085Z'
                     publishedAt: '2020-07-14T23:36:18.598Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -2300,6 +2318,9 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '4665-07-14T23:36:18.598Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -2600,6 +2621,9 @@ paths:
                         value: Tutorial
                     publishedAt: '2019-12-16T08:25:51.000Z'
                     updatedAt: '2019-12-16T08:48:49.000Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -3119,6 +3143,9 @@ paths:
                         value: Tutorial
                     publishedAt: '2019-12-16T08:25:51.000Z'
                     updatedAt: '2019-12-16T08:48:49.000Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
                     assets:
@@ -4814,6 +4841,9 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '4665-07-14T23:36:18.598Z'
+                    removed: false
+                    removedAt: null
+                    deletesAt: null
                     source:
                       uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
                     assets:
@@ -13694,6 +13724,9 @@ components:
             value: Tutorial
         createdAt: '4251-03-03T12:52:03.085Z'
         publishedAt: '4665-07-14T23:36:18.598Z'
+        removed: false
+        removedAt: null
+        deletesAt: null
         actions:
           - video_delete
           - video_download

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13636,6 +13636,9 @@ components:
           format: date-time
           example: '2024-05-28T11:15:07+00:00'
           nullable: true
+        removed:
+          type: boolean
+          description: Returns `true` for videos you removed when you have the Video Restore feature enabled. Returns `false` for every other video.
         tags:
           type: array
           description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -647,7 +647,7 @@ paths:
                         title: This attribute is required.
                         name: title
                       - type: 'https://docs.api.video/reference/invalid-attribute'
-                        title: This attribute must be a ISO8601 date.
+                        title: This attribute must be a ISO-8601 date.
                         name: scheduledAt
                       - type: 'https://docs.api.video/reference/invalid-attribute'
                         title: This attribute must be an array.
@@ -3753,7 +3753,7 @@ paths:
       parameters:
         - name: sortBy
           in: query
-          description: 'Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.'
+          description: 'Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ATOM UTC format.'
           required: false
           style: form
           explode: true
@@ -4997,7 +4997,7 @@ paths:
             `createdAt` - the time a live stream was created.
             `updatedAt` - the time a live stream was last updated.
             
-            When using `createdAt` or `updatedAt`, the API sorts the results based on the ISO-8601 time format.
+            When using `createdAt` or `updatedAt`, the API sorts the results based on the ATOM UTC time format.
           required: false
           style: form
           explode: true
@@ -9669,7 +9669,7 @@ paths:
       parameters:
         - name: sortBy
           in: query
-          description: createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+          description: createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format.
           required: false
           style: form
           explode: true
@@ -9857,7 +9857,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                   req := apivideosdk.PlayerThemesApiListRequest{}
                   
-                  req.SortBy("createdAt") // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+                  req.SortBy("createdAt") // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format.
                   req.SortOrder("asc") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.
                   req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)
                   req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)
@@ -9880,7 +9880,7 @@ paths:
 
               const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
 
-              const sortBy = 'createdAt'; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+              const sortBy = 'createdAt'; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format.
               const sortOrder = 'asc'; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.
               const currentPage = 2; // Choose the number of search results to return per page. Minimum value: 1
               const pageSize = 30; // Results per page. Allowed values 1-100, default is 25.
@@ -9902,7 +9902,7 @@ paths:
               with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
                   # Create an instance of the API class
                   api_instance = player_themes_api.PlayerThemesApi(api_client)
-                  sort_by = "createdAt" # str | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional)
+                  sort_by = "createdAt" # str | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format. (optional)
                   sort_order = "asc" # str | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional)
                   current_page = 2 # int | Choose the number of search results to return per page. Minimum value: 1 (optional) if omitted the server will use the default value of 1
                   page_size = 30 # int | Results per page. Allowed values 1-100, default is 25. (optional) if omitted the server will use the default value of 25
@@ -9934,7 +9934,7 @@ paths:
 
                   PlayerThemesApi apiInstance = client.playerThemes();
                   
-                  String sortBy = "createdAt"; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+                  String sortBy = "createdAt"; // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format.
                   String sortOrder = "asc"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.
                   Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1
                   Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.
@@ -9975,7 +9975,7 @@ paths:
 
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
-                          var sortBy = createdAt;  // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format. (optional) 
+                          var sortBy = createdAt;  // string | createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format. (optional) 
                           var sortOrder = asc;  // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. (optional) 
                           var currentPage = 2;  // int? | Choose the number of search results to return per page. Minimum value: 1 (optional)  (default to 1)
                           var pageSize = 30;  // int? | Results per page. Allowed values 1-100, default is 25. (optional)  (default to 25)
@@ -10004,7 +10004,7 @@ paths:
               require __DIR__ . '/vendor/autoload.php';
 
               $playerThemes = $client->playerThemes()->list(array(
-                  'sortBy' => 'createdAt', // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ISO-8601 format.
+                  'sortBy' => 'createdAt', // createdAt is the time the player was created. updatedAt is the time the player was last updated. The time is presented in ATOM UTC format.
                   'sortOrder' => 'asc', // ->setAllowed(asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones.)
                   'currentPage' => 2, // Choose the number of search results to return per page. Minimum ->setvalue(1)
                   'pageSize' => 30 // Results per page. Allowed values 1-100, default is 25.
@@ -13742,7 +13742,7 @@ components:
         createdAt:
           type: string
           format: date-time
-          description: 'When the watermark was created, presented in ISO-8601 format.'
+          description: 'When the watermark was created, presented in ATOM UTC format.'
           example: '2019-06-24T11:45:01+00:00'
     watermarks-list-response:
       title: Watermarks
@@ -13823,12 +13823,12 @@ components:
           example: pl45KFKdlddgk654dspkze
         createdAt:
           type: string
-          description: 'When the player was created, presented in ISO-8601 format.'
+          description: 'When the player was created, presented in ATOM UTC format.'
           format: date-time
           example: '2020-01-31T10:17:47+00:00'
         updatedAt:
           type: string
-          description: 'When the player was last updated, presented in ISO-8601 format.'
+          description: 'When the player was last updated, presented in ATOM UTC format.'
           format: date-time
           example: '2020-01-31T10:18:47+00:00'
         assets:
@@ -14045,12 +14045,12 @@ components:
             $ref: '#/components/schemas/restreams-response-object'
         createdAt:
           type: string
-          description: 'When the player was created, presented in ISO-8601 format.'
+          description: 'When the player was created, presented in ATOM UTC format.'
           format: date-time
           example: '2020-01-31T10:17:47+00:00'
         updatedAt:
           type: string
-          description: 'When the player was last updated, presented in ISO-8601 format.'
+          description: 'When the player was last updated, presented in ATOM UTC format.'
           format: date-time
           example: '2020-01-31T10:18:47+00:00'
       required:
@@ -14066,7 +14066,7 @@ components:
           example: play
         emittedAt:
           type: string
-          description: 'When an event occurred, presented in ISO-8601 format.'
+          description: 'When an event occurred, presented in ATOM UTC format.'
           format: date-time
           example: '2019-06-24T11:45:01+00:00'
         at:
@@ -14085,7 +14085,7 @@ components:
           example: webhook_XXXXXXXXXXXXXXX
         createdAt:
           type: string
-          description: 'When an webhook was created, presented in ISO-8601 format.'
+          description: 'When an webhook was created, presented in ATOM UTC format.'
           format: date-time
           example: '2019-06-24T11:45:01+00:00'
         events:
@@ -14218,12 +14218,12 @@ components:
           description: Time-to-live - how long the upload token is valid for.
         createdAt:
           type: string
-          description: 'When the token was created, displayed in ISO-8601 format.'
+          description: 'When the token was created, displayed in ATOM UTC format.'
           format: date-time
           example: '2019-12-16T08:25:51+00:00'
         expiresAt:
           type: string
-          description: 'When the token expires, displayed in ISO-8601 format.'
+          description: 'When the token expires, displayed in ATOM UTC format.'
           format: date-time
           example: '2019-12-16T09:25:51+00:00'
           nullable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -243,7 +243,7 @@ paths:
           example: asc
         - name: removed
           in: query
-          description: Use this parameter to return a list of removed videos when you have this feature enabled.
+          description: Use this parameter to return a list of removed videos when you have this feature enabled. This parameter only accepts `true` as a value!
           required: false
           style: form
           explode: false
@@ -14395,9 +14395,8 @@ components:
           items:
             $ref: '#/components/schemas/metadata'
         removed:
+          description: Use this parameter to restore a removed video when you have the Video Restore feature enabled. This parameter only accepts `false` as a value!
           type: boolean
-          description: Use this parameter to restore a removed video. This parameter only accepts `false` as a value.
-          enum: [false]
       example:
         playerId: pl45KFKdlddgk654dspkze
         title: String theory

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13602,8 +13602,8 @@ components:
         createdAt:
           type: string
           format: date-time
-          description: 'When a video was created, presented in ISO-8601 format.'
-          example: '2019-06-24T11:45:01.109+00'
+          description: 'When a video was created, presented in ATOM UTC format.'
+          example: '2024-05-28T11:15:07+00:00'
         title:
           type: string
           description: |
@@ -13616,19 +13616,26 @@ components:
           example: An amazing video explaining string theory.
         publishedAt:
           type: string
-          description: The date and time the API created the video. Date and time are provided using ISO-8601 UTC format.
+          description: The date and time the API created the video. Date and time are provided using ATOM UTC format.
           format: date-time
-          example: '2019-12-16T08:25:51.000Z'
+          example: '2024-05-28T11:15:07+00:00'
         updatedAt:
           type: string
-          description: The date and time the video was updated. Date and time are provided using ISO-8601 UTC format.
+          description: The date and time the video was updated. Date and time are provided using ATOM UTC format.
           format: date-time
-          example: '2019-12-16T08:15:51.000Z'
+          example: '2024-05-28T11:15:07+00:00'
         removedAt:
           type: string
-          description: The date and time the video was removed. The API populates this field only if you have the Video Restore feature enabled. Date and time are provided using ISO-8601 UTC format.
+          description: The date and time the video was removed. The API populates this field only if you have the Video Restore feature enabled and remove a video. Date and time are provided using ATOM UTC format.
           format: date-time
-          example: '2019-12-16T08:15:51.000Z'
+          example: '2024-05-28T11:15:07+00:00'
+          nullable: true
+        deletesAt:
+          type: string
+          description: The date and time the video will be permanently deleted. The API populates this field only if you have the Video Restore feature enabled and remove a video. Removed videos are pemanently deleted after 90 days. Date and time are provided using ATOM UTC format.
+          format: date-time
+          example: '2024-05-28T11:15:07+00:00'
+          nullable: true
         tags:
           type: array
           description: |
@@ -13639,7 +13646,7 @@ components:
         metadata:
           type: array
           description: |
-            Metadata you can use to categorise and filter videos. Metadata is a list of dictionaries, where each dictionary represents a key value pair for categorising a video. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata/) allows you to define a key that allows any value pair.
+            Metadata you can use to categorise and filter videos. Metadata is a list of dictionaries, where each dictionary represents a key value pair for categorising a video.
           example: '[{"key":"Author", "value":"John Doe"}, {"key":"Format", "value":"Tutorial"}]'
           items:
             $ref: '#/components/schemas/metadata'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -291,8 +291,8 @@ paths:
                             value: John Doe
                           - key: Format
                             value: Tutorial
-                        publishedAt: '2019-12-16T08:25:51.000Z'
-                        updatedAt: '2019-12-16T08:48:49.000Z'
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
                         removed: false
                         removedAt: null
                         deletesAt: null
@@ -320,8 +320,8 @@ paths:
                             value: Cyberpunk
                           - key: Technology
                             value: Computers
-                        publishedAt: '2019-12-16T08:25:51.000Z'
-                        updatedAt: '2019-12-16T08:48:49.000Z'
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
                         removed: false
                         removedAt: null
                         deletesAt: null
@@ -346,8 +346,8 @@ paths:
                         metadata:
                           - key: Length
                             value: Short
-                        publishedAt: '2019-12-16T08:25:51.000Z'
-                        updatedAt: '2019-12-16T08:48:49.000Z'
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
                         removed: false
                         removedAt: null
                         deletesAt: null
@@ -585,7 +585,7 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    publishedAt: '2024-07-14T23:36:07+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -999,7 +999,7 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    publishedAt: '2024-07-14T23:36:07+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -1351,7 +1351,7 @@ paths:
                 response:
                   value:
                     watermarkId: watermark_1BWr2L5MTQwxGkuxKjzh6i
-                    createdAt: '2020-03-03T12:52:03.085Z'
+                    createdAt: '2020-03-03T12:52:03+00:00'
         '400':
           headers:
             X-RateLimit-Limit:
@@ -1640,9 +1640,9 @@ paths:
                   value:
                     data:
                       - watermarkId: watermark_1BWr2L5MTQwxGkuxKjzh6i
-                        createdAt: '2019-12-16T08:25:51.000Z'
+                        createdAt: '2019-12-16T08:25:51+00:00'
                       - watermarkId: watermark_3BWC2L5MTQwxGkuxKjzh7g
-                        createdAt: '2019-12-16T08:25:51.000Z'
+                        createdAt: '2019-12-16T08:25:51+00:00'
                     pagination:
                       currentPage: 1
                       pageSize: 25
@@ -1986,8 +1986,8 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    createdAt: '2020-03-03T12:52:03.085Z'
-                    publishedAt: '2020-07-14T23:36:18.598Z'
+                    createdAt: '2020-03-03T12:52:03+00:00'
+                    publishedAt: '2020-07-14T23:36:07+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -2317,7 +2317,7 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    publishedAt: '2024-07-14T23:36:07+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -2619,8 +2619,8 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '2019-12-16T08:25:51.000Z'
-                    updatedAt: '2019-12-16T08:48:49.000Z'
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updatedAt: '2019-12-16T08:48:49+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -3141,8 +3141,8 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '2019-12-16T08:25:51.000Z'
-                    updatedAt: '2019-12-16T08:48:49.000Z'
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updatedAt: '2019-12-16T08:48:49+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -3803,11 +3803,11 @@ paths:
                     data:
                       - token: to37YfoPDRR2pcDKa6LsUE0M
                         ttl: 3600
-                        createdAt: '2020-12-02T10:26:46.000Z'
-                        expiresAt: '2020-12-02T11:26:46.000Z'
+                        createdAt: '2020-12-02T10:26:46+00:00'
+                        expiresAt: '2020-12-02T11:26:46+00:00'
                       - token: to1W3ZS9PdUBZWzzTEZr1B79
                         ttl: 0
-                        createdAt: '2020-12-02T10:26:28.000Z'
+                        createdAt: '2020-12-02T10:26:28+00:00'
                     pagination:
                       currentPage: 1
                       currentPageItems: 2
@@ -4076,8 +4076,8 @@ paths:
                   value:
                     token: to1tcmSFHeYY5KzyhOqVKMKb
                     ttl: 3600
-                    createdAt: '2020-12-02T10:13:19.000Z'
-                    expiresAt: '2020-12-02T11:13:19.000Z'
+                    createdAt: '2020-12-02T10:13:19+00:00'
+                    expiresAt: '2020-12-02T11:13:19+00:00'
         '400':
           headers:
             X-RateLimit-Limit:
@@ -4332,7 +4332,7 @@ paths:
                   value:
                     token: to1tcmSFHeYY5KzyhOqVKMKb
                     ttl: 0
-                    createdAt: '2020-12-02T10:13:19.000Z'
+                    createdAt: '2020-12-02T10:13:19+00:00'
         '404':
           headers:
             X-RateLimit-Limit:
@@ -4840,7 +4840,7 @@ paths:
                         value: John Doe
                       - key: Format
                         value: Tutorial
-                    publishedAt: '4665-07-14T23:36:18.598Z'
+                    publishedAt: '2024-07-14T23:36:07+00:00'
                     removed: false
                     removedAt: null
                     deletesAt: null
@@ -5044,8 +5044,8 @@ paths:
                   value:
                     data:
                       - liveStreamId: li400mYKSgQ6xs7taUeSaEKr
-                        createdAt: '2020-01-31T10:17:47.000Z'
-                        updatedAt: '2020-03-09T13:19:43.000Z'
+                        createdAt: '2020-01-31T10:17:47+00:00'
+                        updatedAt: '2020-03-09T13:19:43+00:00'
                         streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
                         restreams:
                         - name: YouTube
@@ -5063,8 +5063,8 @@ paths:
                           hls: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8'
                           thumbnail: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
                       - liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
-                        createdAt: '2020-07-29T10:45:35.000Z'
-                        updatedAt: '2020-07-29T10:45:35.000Z'
+                        createdAt: '2020-07-29T10:45:35+00:00'
+                        updatedAt: '2020-07-29T10:45:35+00:00'
                         streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
                         restreams:
                         - name: YouTube
@@ -12300,11 +12300,11 @@ paths:
                         from: '2024-05-28T11:08:39+00:00'
                         to: '2024-05-29T11:08:39+00:00'
                     data:
-                    - emittedAt: '2024-05-29T07:00:00+00:00'
+                    - emittedAt: '2024-05-29T07+00:00:00:00'
                       metricValue: 2
-                    - emittedAt: '2024-05-29T08:00:00+00:00'
+                    - emittedAt: '2024-05-29T08+00:00:00:00'
                       metricValue: 1
-                    - emittedAt: '2024-05-29T09:00:00+00:00'
+                    - emittedAt: '2024-05-29T09+00:00:00:00'
                       metricValue: 1
                     pagination:
                       currentPage: 1
@@ -12480,12 +12480,12 @@ paths:
                   value:
                     data:
                       - webhookId: webhook_XXXXXXXXXXXXXXX
-                        createdAt: '2021-01-08T14:12:18.000Z'
+                        createdAt: '2021-01-08T14:12:18+00:00'
                         events:
                           - video.encoding.quality.completed
                         url: 'http://clientnotificationserver.com/notif?myquery=query'
                       - webhookId: webhook_XXXXXXXXXYYYYYY
-                        createdAt: '2021-01-12T12:12:12.000Z'
+                        createdAt: '2021-01-12T12:12:12+00:00'
                         events:
                           - video.encoding.quality.completed
                         url: 'http://clientnotificationserver.com/notif?myquery=query2'
@@ -12743,7 +12743,7 @@ paths:
                 response:
                   value:
                     webhookId: webhook_XXXXXXXXXXXXXXX
-                    createdAt: '2021-01-08T14:12:18.000Z'
+                    createdAt: '2021-01-08T14:12:18+00:00'
                     events:
                       - video.encoding.quality.completed
                     url: 'http://clientnotificationserver.com/notif?myquery=query'
@@ -13024,7 +13024,7 @@ paths:
                 response:
                   value:
                     webhookId: webhook_XXXXXXXXXXXXXXX
-                    createdAt: '2021-01-08T14:12:18.000Z'
+                    createdAt: '2021-01-08T14:12:18+00:00'
                     events:
                       - video.encoding.quality.completed
                     url: 'http://clientnotificationserver.com/notif?myquery=query'
@@ -13442,8 +13442,8 @@ components:
     live-stream-response-example:
       value:
         liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
-        createdAt: '2020-07-29T10:45:35.000Z'
-        updatedAt: '2020-07-29T10:45:35.000Z'
+        createdAt: '2020-07-29T10:45:35+00:00'
+        updatedAt: '2020-07-29T10:45:35+00:00'
         streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
         restreams:
         - name: YouTube
@@ -13722,8 +13722,8 @@ components:
             value: John Doe
           - key: Format
             value: Tutorial
-        createdAt: '4251-03-03T12:52:03.085Z'
-        publishedAt: '4665-07-14T23:36:18.598Z'
+        createdAt: '2024-03-03T12:52:03+00:00'
+        publishedAt: '2024-07-14T23:36:07+00:00'
         removed: false
         removedAt: null
         deletesAt: null
@@ -13743,7 +13743,7 @@ components:
           type: string
           format: date-time
           description: 'When the watermark was created, presented in ISO-8601 format.'
-          example: '2019-06-24T11:45:01.109+00'
+          example: '2019-06-24T11:45:01+00:00'
     watermarks-list-response:
       title: Watermarks
       required:
@@ -14068,7 +14068,7 @@ components:
           type: string
           description: 'When an event occurred, presented in ISO-8601 format.'
           format: date-time
-          example: '2019-06-24T11:45:01.109Z'
+          example: '2019-06-24T11:45:01+00:00'
         at:
           type: integer
         from:
@@ -14087,7 +14087,7 @@ components:
           type: string
           description: 'When an webhook was created, presented in ISO-8601 format.'
           format: date-time
-          example: '2019-06-24T11:45:01.109Z'
+          example: '2019-06-24T11:45:01+00:00'
         events:
           type: array
           description: A list of events that will trigger the webhook.
@@ -14220,12 +14220,12 @@ components:
           type: string
           description: 'When the token was created, displayed in ISO-8601 format.'
           format: date-time
-          example: '2019-12-16T08:25:51.000Z'
+          example: '2019-12-16T08:25:51+00:00'
         expiresAt:
           type: string
           description: 'When the token expires, displayed in ISO-8601 format.'
           format: date-time
-          example: '2019-12-16T09:25:51.000Z'
+          example: '2019-12-16T09:25:51+00:00'
           nullable: true
     authenticate-payload:
       title: ApiKey

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13280,11 +13280,11 @@ paths:
                         from: '2024-05-28T11:08:39+00:00'
                         to: '2024-05-29T11:08:39+00:00'
                     data:
-                    - emittedAt: '2024-05-29T07+00:00:00:00'
+                    - emittedAt: '2024-05-29T07:00:00+00:00'
                       metricValue: 2
-                    - emittedAt: '2024-05-29T08+00:00:00:00'
+                    - emittedAt: '2024-05-29T08:00:00+00:00'
                       metricValue: 1
-                    - emittedAt: '2024-05-29T09+00:00:00:00'
+                    - emittedAt: '2024-05-29T09:00:00+00:00'
                       metricValue: 1
                     pagination:
                       currentPage: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4166,19 +4166,10 @@ paths:
                 response:
                   value:
                     type: 'https://docs.api.video/reference/invalid-attribute'
-                    title: This attribute must be a ISO-8601 date.
-                    name: scheduledAt
+                    title: An attribute is invalid.
+                    detail: Value must be false.
+                    name: discarded
                     status: 400
-                    problems:
-                      - type: 'https://docs.api.video/reference/invalid-attribute'
-                        title: This attribute must be a ISO-8601 date.
-                        name: scheduledAt
-                      - type: 'https://docs.api.video/reference/invalid-attribute'
-                        title: This attribute must be an array.
-                        name: tags
-                      - type: 'https://docs.api.video/reference/invalid-attribute'
-                        title: This attribute must be an array.
-                        name: metadata
         '404':
           headers:
             X-RateLimit-Limit:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -193,7 +193,7 @@ paths:
           example: '["captions", "dialogue"]'
         - name: metadata
           in: query
-          description: 'Videos can be tagged with metadata tags in key:value pairs. You can search for videos with specific key value pairs using this parameter. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata/) allows you to define a key that allows any value pair.'
+          description: 'Videos can be tagged with metadata tags in key:value pairs. You can search for videos with specific key value pairs using this parameter.'
           required: false
           style: deepObject
           x-is-deep-object: true
@@ -241,14 +241,6 @@ paths:
             type: string
             enum: [asc, desc]
           example: asc
-        - name: removed
-          in: query
-          description: Use this parameter to return a list of removed videos when you have this feature enabled. This parameter only accepts `true` as a value!
-          required: false
-          style: form
-          explode: false
-          schema:
-            type: boolean
         - $ref: '#/components/parameters/current-page'
         - $ref: '#/components/parameters/page-size'
       responses:
@@ -293,8 +285,8 @@ paths:
                             value: Tutorial
                         publishedAt: '2019-12-16T08:25:51+00:00'
                         updatedAt: '2019-12-16T08:48:49+00:00'
-                        removed: false
-                        removedAt: null
+                        discarded: false
+                        discardedAt: null
                         deletesAt: null
                         source:
                           uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
@@ -322,8 +314,8 @@ paths:
                             value: Computers
                         publishedAt: '2019-12-16T08:25:51+00:00'
                         updatedAt: '2019-12-16T08:48:49+00:00'
-                        removed: false
-                        removedAt: null
+                        discarded: false
+                        discardedAt: null
                         deletesAt: null
                         source:
                           uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -348,8 +340,8 @@ paths:
                             value: Short
                         publishedAt: '2019-12-16T08:25:51+00:00'
                         updatedAt: '2019-12-16T08:48:49+00:00'
-                        removed: false
-                        removedAt: null
+                        discarded: false
+                        discardedAt: null
                         deletesAt: null
                         source:
                           uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -586,8 +578,8 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '2024-07-14T23:36:07+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -1000,8 +992,8 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '2024-07-14T23:36:07+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -1988,8 +1980,8 @@ paths:
                         value: Tutorial
                     createdAt: '2020-03-03T12:52:03+00:00'
                     publishedAt: '2020-07-14T23:36:07+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -2318,8 +2310,8 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '2024-07-14T23:36:07+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -2621,8 +2613,8 @@ paths:
                         value: Tutorial
                     publishedAt: '2019-12-16T08:25:51+00:00'
                     updatedAt: '2019-12-16T08:48:49+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -2849,11 +2841,11 @@ paths:
       description: |
         Delete a video object by video ID. 
         
-        By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will remove the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! 
+        By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will discard the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! 
         
         The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted.       
       x-client-description:
-        default: 'If you do not need a video any longer, you can send a request to delete it. All you need is the videoId. By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will remove the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted'
+        default: 'If you do not need a video any longer, you can send a request to delete it. All you need is the videoId. By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will discard the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted'
       operationId: DELETE-video
       parameters:
         - name: videoId
@@ -3143,8 +3135,8 @@ paths:
                         value: Tutorial
                     publishedAt: '2019-12-16T08:25:51+00:00'
                     updatedAt: '2019-12-16T08:48:49+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
@@ -3154,6 +3146,1003 @@ paths:
                       hls: 'https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/hls/manifest.m3u8'
                       thumbnail: 'https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/thumbnail.jpg'
                       mp4: 'https://cdn.api.video/vod/vi4blUQJFrYWbaG44NChkH27/mp4/source.mp4'
+        '400':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/reference/invalid-attribute'
+                    title: This attribute must be a ISO-8601 date.
+                    name: scheduledAt
+                    status: 400
+                    problems:
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
+                        title: This attribute must be a ISO-8601 date.
+                        name: scheduledAt
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
+                        title: This attribute must be an array.
+                        name: tags
+                      - type: 'https://docs.api.video/reference/invalid-attribute'
+                        title: This attribute must be an array.
+                        name: metadata
+        '404':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/reference/resource-not-found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+        '429':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/too-many-requests'
+              examples:
+                Too many requests:
+                  value:
+                    type: 'https://docs.api.video/reference/too-many-requests'
+                    title: Too many requests.
+                    status: 429
+      security:
+        - apiKey: []
+      x-client-action: update
+      x-doctave:
+        code-samples:
+          - language: go
+            code: |
+              // First install the go client with "go get github.com/apivideo/api.video-go-client"
+              // Documentation: https://github.com/apivideo/api.video-go-client/blob/main/docs/VideosApi.md#update
+
+              package main
+
+              import (
+                  "context"
+                  "fmt"
+                  "os"
+                  apivideosdk "github.com/apivideo/api.video-go-client"
+              )
+
+              func main() {
+                  client := apivideosdk.ClientBuilder("YOUR_API_KEY").Build()
+                  // if you rather like to use the sandbox environment:
+                  // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
+                      
+                  videoId := "vi4k0jvEUuaTdRAEjQ4Jfrgz" // string | The video ID for the video you want to delete.
+                  videoUpdatePayload := *apivideosdk.NewVideoUpdatePayload() // VideoUpdatePayload | 
+
+                  
+                  res, err := client.Videos.Update(videoId, videoUpdatePayload)
+
+                  if err != nil {
+                      fmt.Fprintf(os.Stderr, "Error when calling `Videos.Update``: %v\
+              ", err)
+                  }
+                  // response from `Update`: Video
+                  fmt.Fprintf(os.Stdout, "Response from `Videos.Update`: %v\
+              ", res)
+              }
+          - language: node
+            code: |
+              // First install the "@api.video/nodejs-client" npm package
+              // Documentation: https://github.com/apivideo/api.video-nodejs-client/blob/main/doc/api/VideosApi.md#update
+
+              const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
+
+              const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to update.
+
+              // define the value you want to update
+              const videoUpdatePayload = {
+                  playerId: "pl4k0jvEUuaTdRAEjQ4Jfrgz", // The unique ID for the player you want to associate with your video.
+                  title: "title_example", // The title you want to use for your video.
+                  description: "A film about good books.", // A brief description of the video.
+                  _public: true, // Whether the video is publicly available or not. False means it is set to private.
+                  panoramic: false, // Whether the video is a 360 degree or immersive video.
+                  mp4Support: true, // Whether the player supports the mp4 format.
+                  tags: ["maths", "string theory", "video"], // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.
+                  metadata: [{"key": "Author", "value": "John Doe"}], // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.
+              }; 
+
+
+              const updatedVideo = await client.videos.update(videoId, videoUpdatePayload);
+          - language: python
+            code: |
+              # First install the api client with "pip install api.video"
+              # Documentation: https://github.com/apivideo/api.video-python-client/blob/main/docs/VideosApi.md#update
+
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.video_update_payload import VideoUpdatePayload
+              from apivideo.model.bad_request import BadRequest
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.video import Video
+              from pprint import pprint
+
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "vi4k0jvEUuaTdRAEjQ4Jfrgz" # str | The video ID for the video you want to delete.
+                  video_update_payload = VideoUpdatePayload(
+                      player_id="pl4k0jvEUuaTdRAEjQ4Jfrgz",
+                      title="title_example",
+                      description="A film about good books.",
+                      public=True,
+                      panoramic=False,
+                      mp4_support=True,
+                      tags=["maths", "string theory", "video"],
+                      metadata=[
+                          Metadata(
+                              key="Color",
+                              value="Green",
+                          ),
+                      ],
+                  ) # VideoUpdatePayload | 
+
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Update a video
+                      api_response = api_instance.update(video_id, video_update_payload)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->update: %s\
+              " % e)              
+          - language: java
+            code: |
+              // First add the "video.api:java-api-client" maven dependency to your project
+              // Documentation: https://github.com/apivideo/api.video-java-client/blob/main/docs/VideosApi.md#update
+
+              import video.api.client.ApiVideoClient;
+              import video.api.client.api.ApiException;
+              import video.api.client.api.models.*;
+              import video.api.client.api.clients.VideosApi;
+              import java.util.*;
+
+              public class Example {
+                public static void main(String[] args) {
+                  ApiVideoClient client = new ApiVideoClient("YOUR_API_KEY");
+                  // if you rather like to use the sandbox environment:
+                  // ApiVideoClient client = new ApiVideoClient("YOUR_SANDBOX_API_KEY", ApiVideoClient.Environment.SANDBOX);
+
+                  VideosApi apiInstance = client.videos();
+                  
+                  String videoId = "vi4k0jvEUuaTdRAEjQ4Jfrgz"; // The video ID for the video you want to delete.
+                  VideoUpdatePayload videoUpdatePayload = new VideoUpdatePayload(); // 
+                  videoUpdatePayload.setPlayerId("pl4k0jvEUuaTdRAEjQ4Jfrgz"); // The unique ID for the player you want to associate with your video.
+                  videoUpdatePayload.setTitle("null"); // The title you want to use for your video.
+                  videoUpdatePayload.setDescription("A film about good books."); // A brief description of the video.
+                  videoUpdatePayload.setPublic(true); // Whether the video is publicly available or not. False means it is set to private.
+                  videoUpdatePayload.setPanoramic(false); // Whether the video is a 360 degree or immersive video.
+                  videoUpdatePayload.setMp4Support(true); // Whether the player supports the mp4 format.
+                  videoUpdatePayload.setTags(Arrays.asList("maths", "string theory", "video")); // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.
+                  videoUpdatePayload.setMetadata(Collections.<Metadata>emptyList()); // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.
+
+
+                  try {
+                    Video result = apiInstance.update(videoId, videoUpdatePayload);
+                    System.out.println(result);
+                  } catch (ApiException e) {
+                    System.err.println("Exception when calling VideosApi#update");
+                    System.err.println("Status code: " + e.getCode());
+                    System.err.println("Reason: " + e.getMessage());
+                    System.err.println("Response headers: " + e.getResponseHeaders());
+                    e.printStackTrace();
+                  }
+                }
+              }
+          - language: csharp
+            code: |
+              // First add the "ApiVideo" NuGet package to your project
+              // Documentation: https://github.com/apivideo/api.video-csharp-client/blob/main/docs/VideosApi.md#update
+
+              using System.Diagnostics;
+              using ApiVideo.Client;
+
+              namespace Example
+              {
+                  public class updateExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
+
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
+
+                          var videoId = vi4k0jvEUuaTdRAEjQ4Jfrgz;  // string | The video ID for the video you want to delete.
+                          var videoUpdatePayload = new VideoUpdatePayload(); // VideoUpdatePayload | 
+                          var apiVideosInstance = apiInstance.Videos();
+                          try
+                          {
+                              // Update a video
+                              Video result = apiVideosInstance.update(videoId, videoUpdatePayload);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling VideosApi.update: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              }
+          - language: php
+            code: |-
+              <?php
+              // First install the api client: "composer require api-video/php-api-client"
+              // Documentation: https://github.com/apivideo/api.video-php-client/blob/main/docs/Api/VideosApi.md#update
+
+              require __DIR__ . '/vendor/autoload.php';
+
+              $client = new \ApiVideo\Client\Client(
+                  'https://ws.api.video',
+                  'YOUR_API_KEY',
+                  new \Symfony\Component\HttpClient\Psr18Client()
+              );
+
+              $videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The video ID for the video you want to update.
+
+              $client->videos()->update($videoId, (new \ApiVideo\Client\Model\VideoUpdatePayload())
+                  ->setPlayerId("pl4k0jvEUuaTdRAEjQ4Jfrgz") // The unique ID for the player you want to associate with your video.
+                  ->setTitle("The new title") // The title you want to use for your video.
+                  ->setDescription("A new description") // A brief description of the video.
+                  ->setPublic(false) // Whether the video is publicly available or not. False means it is set to private.
+                  ->setPanoramic(false) // Whether the video is a 360 degree or immersive video.
+                  ->setMp4Support(true) // Whether the player supports the mp4 format.
+                  ->setTags(["tag1", "tag2"]) // A list of terms or words you want to tag the video with. Make sure the list includes all the tags you want as whatever you send in this list will overwrite the existing list for the video.
+                  ->setMetadata(array( // A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.
+                      new \ApiVideo\Client\Model\Metadata(["key" => "aa", 'value' => "bb"]),
+                      new \ApiVideo\Client\Model\Metadata(["key" => "aa2", 'value' => "bb2"])))); 
+          - language: swift
+            code: |
+              // First install the api client: https://github.com/apivideo/api.video-swift-client#getting-started
+              // Documentation: https://github.com/apivideo/api.video-swift-client/blob/main/docs/VideosAPI.md#update  
+  /discarded/videos:
+    get:
+      tags:
+        - Videos
+      summary: List all discarded video objects
+      description: List all the video objects that are associated with the current workspace.
+      x-client-description:
+        default: 'This method returns a list of your discarded videos (with all their details). With no parameters added, the API returns the first page of all discarded videos. You can filter discarded videos using the parameters described below.'
+      operationId: LIST-discarded-videos
+      parameters:
+        - name: title
+          in: query
+          description: The title of a specific video you want to find. The search will match exactly to what term you provide and return any videos that contain the same term as part of their titles.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: My Video.mp4
+        - name: 'tags[]'
+          in: query
+          description: A tag is a category you create and apply to videos. You can search for videos with particular tags by listing one or more here. Only videos that have all the tags you list will be returned.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example: '["captions", "dialogue"]'
+        - name: metadata
+          in: query
+          description: 'Videos can be tagged with metadata tags in key:value pairs. You can search for videos with specific key value pairs using this parameter.'
+          required: false
+          style: deepObject
+          x-is-deep-object: true
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+          example: 'metadata[Author]=John Doe&metadata[Format]=Tutorial'
+        - name: description
+          in: query
+          description: 'Retrieve video objects by `description`.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: New Zealand
+        - name: liveStreamId
+          in: query
+          description: 'Retrieve video objects that were recorded from a live stream by `liveStreamId`.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: li400mYKSgQ6xs7taUeSaEKr
+        - name: sortBy
+          in: query
+          description: 'Use this parameter to sort videos by the their created time, published time, updated time, or by title.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum: [title, createdAt, publishedAt, updatedAt]
+          example: publishedAt
+        - name: sortOrder
+          in: query
+          description: 'Use this parameter to sort results. `asc` is ascending and sorts from A to Z. `desc` is descending and sorts from Z to A.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum: [asc, desc]
+          example: asc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
+      responses:
+        '200':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/videos-list-response'
+              examples:
+                response:
+                  value:
+                    data:
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: Maths video
+                        description: An amazing video explaining the string theory
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - maths
+                          - string theory
+                          - video
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Format
+                            value: Tutorial
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
+                        discarded: true
+                        discardedAt: '2024-10-16T08:48:49+00:00'
+                        deletesAt: '2024-11-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/c188ed58-3403-46a2-b91b-44603d10b2c9/source
+                        assets:
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        title: Video Title
+                        description: A description for your video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - books
+                          - short stories
+                        metadata:
+                          - key: Author
+                            value: John Doe
+                          - key: Science Fiction
+                            value: Cyberpunk
+                          - key: Technology
+                            value: Computers
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
+                        discarded: true
+                        discardedAt: '2024-10-16T08:48:49+00:00'
+                        deletesAt: '2024-11-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                        assets:
+                      - videoId: vi4blUQJFrYWbaG44NChkH27
+                        playerId: pl45KFKdlddgk654dspkze
+                        title: My Video Title
+                        description: A brief description of the video.
+                        public: false
+                        panoramic: false
+                        mp4Support: true
+                        tags:
+                          - General
+                          - Videos
+                        metadata:
+                          - key: Length
+                            value: Short
+                        publishedAt: '2019-12-16T08:25:51+00:00'
+                        updatedAt: '2019-12-16T08:48:49+00:00'
+                        discarded: true
+                        discardedAt: '2024-10-16T08:48:49+00:00'
+                        deletesAt: '2024-11-16T08:48:49+00:00'
+                        source:
+                          uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                        assets:
+                    pagination:
+                      currentPage: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 11
+                      currentPageItems: 11
+                      links:
+                        - rel: self
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/videos?currentPage=1'
+        '400':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                response:
+                  value:
+                    title: This parameter is out of the allowed range of values.
+                    name: page
+                    status: 400
+                    range:
+                      min: 1
+                    problems:
+                      - title: This parameter is out of the allowed range of values.
+                        name: page
+                        range:
+                          min: 1
+                      - title: This parameter is out of the allowed range of values.
+                        name: pageSize
+                        range:
+                          min: 10
+                          max: 100
+        '429':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/too-many-requests'
+              examples:
+                Too many requests:
+                  value:
+                    type: 'https://docs.api.video/reference/too-many-requests'
+                    title: Too many requests.
+                    status: 429
+      security:
+        - apiKey: []
+      x-doctave:
+        code-samples:
+          - language: php
+            code: |
+              <?php
+              // First install the api client: "composer require api-video/php-api-client"
+              // Documentation: https://github.com/apivideo/api.video-php-client/blob/main/docs/Api/VideosApi.md#list
+
+              require __DIR__ . '/vendor/autoload.php';
+
+
+              $client = new \ApiVideo\Client\Client(
+                  'https://ws.api.video',
+                  'YOUR_API_KEY',
+                  new \Symfony\Component\HttpClient\Psr18Client()
+              );
+
+              // list all videos (all pages)
+              $allVideos = [];
+              do {
+                  $currentPage = $client->videos()->list([]);
+                  $allVideos = array_merge($allVideos, $currentPage->getData());
+              } while($currentPage->getPagination()->getCurrentPage() < $currentPage->getPagination()->getPagesTotal());
+
+              // list videos that have all the given tags (only first results page)
+              $videosWithTag = $client->videos()->list(['tags' => ['TAG2','TAG1']]);
+
+              // list videos that have all the given metadata values (only first results page)
+              $videosWithMetadata = $client->videos()->list(['metadata' => ['key1' => 'key1value1', 'key2' => 'key2value1']]);
+          - language: java
+            code: |-
+              // First add the "video.api:java-api-client" maven dependency to your project
+              // Documentation: https://github.com/apivideo/api.video-java-client/blob/main/docs/VideosApi.md#list
+
+              ApiVideoClient client = new ApiVideoClient("YOUR_API_KEY");
+              VideosApi videosApi = client.videos();
+
+              // list all videos (all pages)
+              Page<Video> videosPages = videosApi.list().execute();
+              videosPages.forEach(videosPage -> videosPage.getItems().forEach(video ->
+                  System.out.println(video.getVideoId())
+              ));
+
+              // list videos that have all the given tags (only first results page)
+              List<Video> videosWithTags = videosApi.list()
+                  .tags(Arrays.asList("tag1", "tag2"))
+                  .execute()
+                  .getItems();
+
+              // list videos that have all the given metadata values (only first results page)
+              List<Video> videosWithMetadata = videosApi.list()
+                  .metadata(Map.of("key1", "value1", "key2", "value2"))
+                  .execute()
+                  .getItems();
+          - language: node
+            code: |-
+              // First install the "@api.video/nodejs-client" npm package
+              // Documentation: https://github.com/apivideo/api.video-nodejs-client/blob/main/doc/api/VideosApi.md#list
+
+              const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
+
+              // list all videos (all pages)
+              let allVideos = [];
+              for(let currentPage=1 ; ; currentPage++) {
+                const res = await client.videos.list({ currentPage });
+                allVideos = [...allVideos, ...res.data];
+                if(currentPage >= res.pagination.pagesTotal) {
+                  break;
+                }
+              }
+
+              // list videos that have all the given tags (only first results page)
+              const videosWithTags = await client.videos.list({ tags: ["tag1", "tag2"] });
+
+              // list videos that have all the given metadata values (only first results page)
+              const videosWithMetadata = await client.videos.list({ metadata: { "key1": "value1", "key2": "value2" } })
+          - language: csharp
+            code: |
+              // First add the "ApiVideo" NuGet package to your project
+              // Documentation: https://github.com/apivideo/api.video-csharp-client/blob/main/docs/VideosApi.md#list
+          - language: go
+            code: |
+              // First install the go client with "go get github.com/apivideo/api.video-go-client"
+              // Documentation: https://github.com/apivideo/api.video-go-client/blob/main/docs/VideosApi.md#list
+          - language: python
+            code: |
+              # First install the api client with "pip install api.video"
+              # Documentation: https://github.com/apivideo/api.video-python-client/blob/main/docs/VideosApi.md#list
+          - language: swift
+            code: |
+              // First install the api client: https://github.com/apivideo/api.video-swift-client#getting-started
+              // Documentation: https://github.com/apivideo/api.video-swift-client/blob/main/docs/VideosAPI.md#list
+      x-client-action: list
+      x-group-parameters: true
+      x-client-paginated: true
+      x-optional-object: true
+  '/discarded/videos/{videoId}':
+    get:
+      tags:
+        - Videos
+      summary: Retrieve a discarded video object
+      description: Retrieve the video details of a discarded video object by video id.
+      x-client-description:
+        default: 'This call provides the same information provided on video creation. For private videos, it will generate a unique token url. Use this to retrieve any details you need about a video, or set up a private viewing URL.'
+      operationId: GET-discarded-video
+      parameters:
+        - name: videoId
+          in: path
+          description: The unique identifier for the video you want details about.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4blUQJFrYWbaG44NChkH27
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updatedAt: '2019-12-16T08:48:49+00:00'
+                    discarded: true
+                    discardedAt: '2024-10-16T08:48:49+00:00'
+                    deletesAt: '2024-11-16T08:48:49+00:00'
+                    source:
+                      uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                    assets:
+        '404':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/reference/resource-not-found'
+                    title: The requested resource was not found.
+                    name: videoId
+                    status: 404
+        '429':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/too-many-requests'
+              examples:
+                Too many requests:
+                  value:
+                    type: 'https://docs.api.video/reference/too-many-requests'
+                    title: Too many requests.
+                    status: 429
+      security:
+        - apiKey: []
+      x-client-action: get
+      x-doctave:
+        code-samples:
+          - language: go
+            code: |
+              // First install the go client with "go get github.com/apivideo/api.video-go-client"
+              // Documentation: https://github.com/apivideo/api.video-go-client/blob/main/docs/VideosApi.md#get
+
+              package main
+
+              import (
+                  "context"
+                  "fmt"
+                  "os"
+                  apivideosdk "github.com/apivideo/api.video-go-client"
+              )
+
+              func main() {
+                  client := apivideosdk.ClientBuilder("YOUR_API_KEY").Build()
+                  // if you rather like to use the sandbox environment:
+                  // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
+                      
+                  videoId := "videoId_example" // string | The unique identifier for the video you want details about.
+
+                  
+                  res, err := client.Videos.Get(videoId)
+
+                  if err != nil {
+                      fmt.Fprintf(os.Stderr, "Error when calling `Videos.Get``: %v\
+              ", err)
+                  }
+                  // response from `Get`: Video
+                  fmt.Fprintf(os.Stdout, "Response from `Videos.Get`: %v\
+              ", res)
+              }
+          - language: node
+            code: |
+              // First install the "@api.video/nodejs-client" npm package
+              // Documentation: https://github.com/apivideo/api.video-nodejs-client/blob/main/doc/api/VideosApi.md#get
+
+              const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
+
+              const videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want to retrieve.
+              const result = await client.videos.get(videoId);  
+          - language: python
+            code: |
+              # First install the api client with "pip install api.video"
+              # Documentation: https://github.com/apivideo/api.video-python-client/blob/main/docs/VideosApi.md#get
+
+              import apivideo
+              from apivideo.api import videos_api
+              from apivideo.model.not_found import NotFound
+              from apivideo.model.video import Video
+              from pprint import pprint
+
+              # Enter a context with an instance of the API client
+              with apivideo.AuthenticatedApiClient(__API_KEY__) as api_client:
+                  # Create an instance of the API class
+                  api_instance = videos_api.VideosApi(api_client)
+                  video_id = "videoId_example" # str | The unique identifier for the video you want details about.
+
+                  # example passing only required values which don't have defaults set
+                  try:
+                      # Show a video
+                      api_response = api_instance.get(video_id)
+                      pprint(api_response)
+                  except apivideo.ApiException as e:
+                      print("Exception when calling VideosApi->get: %s\n" % e)
+          - language: java
+            code: |
+              // First add the "video.api:java-api-client" maven dependency to your project
+              // Documentation: https://github.com/apivideo/api.video-java-client/blob/main/docs/VideosApi.md#get
+
+              import video.api.client.ApiVideoClient;
+              import video.api.client.api.ApiException;
+              import video.api.client.api.models.*;
+              import video.api.client.api.clients.VideosApi;
+              import java.util.*;
+
+              public class Example {
+                public static void main(String[] args) {
+                  ApiVideoClient client = new ApiVideoClient("YOUR_API_KEY");
+                  // if you rather like to use the sandbox environment:
+                  // ApiVideoClient client = new ApiVideoClient("YOUR_SANDBOX_API_KEY", ApiVideoClient.Environment.SANDBOX);
+
+                  VideosApi apiInstance = client.videos();
+                  
+                  String videoId = "videoId_example"; // The unique identifier for the video you want details about.
+
+                  try {
+                    Video result = apiInstance.get(videoId);
+                    System.out.println(result);
+                  } catch (ApiException e) {
+                    System.err.println("Exception when calling VideosApi#get");
+                    System.err.println("Status code: " + e.getCode());
+                    System.err.println("Reason: " + e.getMessage());
+                    System.err.println("Response headers: " + e.getResponseHeaders());
+                    e.printStackTrace();
+                  }
+                }
+              }  
+          - language: csharp
+            code: |
+              // First add the "ApiVideo" NuGet package to your project
+              // Documentation: https://github.com/apivideo/api.video-csharp-client/blob/main/docs/VideosApi.md#get
+
+              using System.Diagnostics;
+              using ApiVideo.Client;
+
+              namespace Example
+              {
+                  public class getExample
+                  {
+                      public static void Main()
+                      {
+                          var basePath = ApiVideoClient.Client.Environment.SANDBOX;
+                          var apiKey = "YOUR_API_KEY";
+
+                          var apiInstance = new ApiVideoClient(apiKey,basePath);
+
+                          var videoId = videoId_example;  // string | The unique identifier for the video you want details about.
+                          var apiVideosInstance = apiInstance.Videos();
+                          try
+                          {
+                              // Show a video
+                              Video result = apiVideosInstance.get(videoId);
+                              Debug.WriteLine(result);
+                          }
+                          catch (ApiException  e)
+                          {
+                              Debug.Print("Exception when calling VideosApi.get: " + e.Message );
+                              Debug.Print("Status Code: "+ e.ErrorCode);
+                              Debug.Print(e.StackTrace);
+                          }
+                      }
+                  }
+              } 
+          - language: php
+            code: |-
+              <?php
+              // First install the api client: "composer require api-video/php-api-client"
+              // Documentation: https://github.com/apivideo/api.video-php-client/blob/main/docs/Api/VideosApi.md#getStatus
+
+              require __DIR__ . '/vendor/autoload.php';
+
+              $client = new \ApiVideo\Client\Client(
+                  'https://ws.api.video',
+                  'YOUR_API_KEY',
+                  new \Symfony\Component\HttpClient\Psr18Client()
+              );
+
+              $videoId = 'vi4k0jvEUuaTdRAEjQ4Jfrgz'; // The unique identifier for the video you want the status for.
+              $videoStatus = $client->videos()->getStatus($videoId);  
+          - language: swift
+            code: |
+              // First install the api client: https://github.com/apivideo/api.video-swift-client#getting-started
+              // Documentation: https://github.com/apivideo/api.video-swift-client/blob/main/docs/VideosAPI.md#get
+    patch:
+      tags:
+        - Videos
+      summary: Update a discarded video object
+      description: Restore a discarded video
+      x-client-description:
+        default: |
+          Use this endpoint to restore a discarded video when you have the Video Restore feature enabled.
+      operationId: PATCH-discarded-video
+      parameters:
+        - name: videoId
+          in: path
+          description: The video ID for the video you want to restore.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/discarded-video-update-payload'
+      responses:
+        '200':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/video'
+              examples:
+                response:
+                  value:
+                    videoId: vi4blUQJFrYWbaG44NChkH27
+                    playerId: pl45KFKdlddgk654dspkze
+                    title: Maths video
+                    description: An amazing video explaining the string theory
+                    public: false
+                    panoramic: false
+                    mp4Support: true
+                    tags:
+                      - maths
+                      - string theory
+                      - video
+                    metadata:
+                      - key: Author
+                        value: John Doe
+                      - key: Format
+                        value: Tutorial
+                    publishedAt: '2019-12-16T08:25:51+00:00'
+                    updatedAt: '2019-12-16T08:48:49+00:00'
+                    discarded: true
+                    discardedAt: '2024-10-16T08:48:49+00:00'
+                    deletesAt: '2024-11-16T08:48:49+00:00'
+                    source:
+                      uri: /videos/vi4blUQJFrYWbaG44NChkH27/source
+                    assets:
         '400':
           headers:
             X-RateLimit-Limit:
@@ -4841,8 +5830,8 @@ paths:
                       - key: Format
                         value: Tutorial
                     publishedAt: '2024-07-14T23:36:07+00:00'
-                    removed: false
-                    removedAt: null
+                    discarded: false
+                    discardedAt: null
                     deletesAt: null
                     source:
                       uri: /videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/source
@@ -13654,21 +14643,21 @@ components:
           description: The date and time the video was updated. Date and time are provided using ATOM UTC format.
           format: date-time
           example: '2024-05-28T11:15:07+00:00'
-        removedAt:
+        discardedAt:
           type: string
-          description: The date and time the video was removed. The API populates this field only if you have the Video Restore feature enabled and remove a video. Date and time are provided using ATOM UTC format.
+          description: The date and time the video was discarded. The API populates this field only if you have the Video Restore feature enabled and discard a video. Date and time are provided using ATOM UTC format.
           format: date-time
           example: '2024-05-28T11:15:07+00:00'
           nullable: true
         deletesAt:
           type: string
-          description: The date and time the video will be permanently deleted. The API populates this field only if you have the Video Restore feature enabled and remove a video. Removed videos are pemanently deleted after 90 days. Date and time are provided using ATOM UTC format.
+          description: The date and time the video will be permanently deleted. The API populates this field only if you have the Video Restore feature enabled and discard a video. Discarded videos are pemanently deleted after 90 days. Date and time are provided using ATOM UTC format.
           format: date-time
           example: '2024-05-28T11:15:07+00:00'
           nullable: true
-        removed:
+        discarded:
           type: boolean
-          description: Returns `true` for videos you removed when you have the Video Restore feature enabled. Returns `false` for every other video.
+          description: Returns `true` for videos you discarded when you have the Video Restore feature enabled. Returns `false` for every other video.
         tags:
           type: array
           description: |
@@ -13724,8 +14713,8 @@ components:
             value: Tutorial
         createdAt: '2024-03-03T12:52:03+00:00'
         publishedAt: '2024-07-14T23:36:07+00:00'
-        removed: false
-        removedAt: null
+        discarded: false
+        discardedAt: null
         deletesAt: null
         actions:
           - video_delete
@@ -14341,7 +15330,7 @@ components:
             type: string
         metadata:
           type: array
-          description: 'A list of key value pairs that you use to provide metadata for your video. These pairs can be made dynamic, allowing you to segment your audience. Read more on [dynamic metadata](https://api.video/blog/endpoints/dynamic-metadata/).'
+          description: 'A list of key value pairs that you use to provide metadata for your video.'
           example: '[{"key": "Author", "value": "John Doe"}]'
           items:
             $ref: '#/components/schemas/metadata'
@@ -14427,12 +15416,9 @@ components:
             type: string
         metadata:
           type: array
-          description: 'A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata/) allows you to define a key that allows any value pair.'
+          description: 'A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video.'
           items:
             $ref: '#/components/schemas/metadata'
-        removed:
-          description: Use this parameter to restore a removed video when you have the Video Restore feature enabled. This parameter only accepts `false` as a value!
-          type: boolean
       example:
         playerId: pl45KFKdlddgk654dspkze
         title: String theory
@@ -14449,6 +15435,15 @@ components:
             value: John Doe
           - key: Format
             value: Tutorial
+    discarded-video-update-payload:
+      title: DiscardedVideoUpdatePayload
+      type: object
+      properties:
+        discarded:
+          description: Use this parameter to restore a discarded video when you have the Video Restore feature enabled. This parameter only accepts `false` as a value!
+          type: boolean
+      example:
+        discarded: false
     token-list-response:
       title: UploadTokens
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -241,6 +241,14 @@ paths:
             type: string
             enum: [asc, desc]
           example: asc
+        - name: removed
+          in: query
+          description: Use this parameter to return a list of removed videos when you have this feature enabled.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: boolean
         - $ref: '#/components/parameters/current-page'
         - $ref: '#/components/parameters/page-size'
       responses:
@@ -2814,9 +2822,14 @@ paths:
       tags:
         - Videos
       summary: Delete a video object
-      description: Delete a video object by video ID.
+      description: |
+        Delete a video object by video ID. 
+        
+        By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will remove the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! 
+        
+        The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted.       
       x-client-description:
-        default: 'If you do not need a video any longer, you can send a request to delete it. All you need is the videoId.'
+        default: 'If you do not need a video any longer, you can send a request to delete it. All you need is the videoId. By default, deleted videos cannot be recovered. If you have the Video Restore feature enabled, this operation will remove the video instead of permanently deleting it. Make sure you subscribe to the Video Restore feature if you want to be able to restore deleted videos! The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted'
       operationId: DELETE-video
       parameters:
         - name: videoId
@@ -13611,6 +13624,11 @@ components:
           description: The date and time the video was updated. Date and time are provided using ISO-8601 UTC format.
           format: date-time
           example: '2019-12-16T08:15:51.000Z'
+        removedAt:
+          type: string
+          description: The date and time the video was removed. The API populates this field only if you have the Video Restore feature enabled. Date and time are provided using ISO-8601 UTC format.
+          format: date-time
+          example: '2019-12-16T08:15:51.000Z'
         tags:
           type: array
           description: |
@@ -14369,6 +14387,10 @@ components:
           description: 'A list (array) of dictionaries where each dictionary contains a key value pair that describes the video. As with tags, you must send the complete list of metadata you want as whatever you send here will overwrite the existing metadata for the video. [Dynamic Metadata](https://api.video/blog/endpoints/dynamic-metadata/) allows you to define a key that allows any value pair.'
           items:
             $ref: '#/components/schemas/metadata'
+        removed:
+          type: boolean
+          description: Use this parameter to restore a removed video. This parameter only accepts `false` as a value.
+          enum: [false]
       example:
         playerId: pl45KFKdlddgk654dspkze
         title: String theory

--- a/vod/add-a-thumbnail-to-your-video.md
+++ b/vod/add-a-thumbnail-to-your-video.md
@@ -137,7 +137,14 @@ print(response)
 
 ## Pick a thumbnail
 
-If you don't want to create a custom thumbnail image for your video, you can select one from the video itself. All you need to do is choose the timecode to the frame you want to be the thumbnail. The format is ISO 8601, and represents - HH:MM:SS:mm - hours, minutes, seconds, milliseconds.
+If you don't want to create a custom thumbnail image for your video, you can select one from the video itself. All you need to do is choose the timecode to the frame you want to be the thumbnail. The accepted formats are:
+
+- `HH:MM:SS.mm` - hours, minutes, seconds, milliseconds
+- `hh:mm:ss:frameNumber`
+- `int` - integer value is reported as seconds
+
+If your selection is out of range, `00:00:00.00` will be used.
+
 
 <CodeSelect title="Picking a thumbnail">
 ```curl

--- a/vod/delegated-upload-tokens.md
+++ b/vod/delegated-upload-tokens.md
@@ -329,7 +329,7 @@ func main() {
     // client := apivideosdk.SandboxClientBuilder("YOU_SANDBOX_API_TOKEN").Build()
     req := apivideosdk.UploadTokensApiListRequest{}
     
-    req.SortBy("ttl") // string | Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.
+    req.SortBy("ttl") // string | Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ATOM UTC format.
     req.SortOrder("asc") // string | Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.
     req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)
     req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)
@@ -373,7 +373,7 @@ const ApiVideoClient = require('@api.video/nodejs-client');
     try {
         const client = new ApiVideoClient({ apiKey: "YOUR_API_TOKEN" });
 
-        const sortBy = 'ttl'; // Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ISO-8601 format.
+        const sortBy = 'ttl'; // Allowed: createdAt, ttl. You can use these to sort by when a token was created, or how much longer the token will be active (ttl - time to live). Date and time is presented in ATOM UTC format.
         const sortOrder = 'asc'; // Allowed: asc, desc. Ascending is 0-9 or A-Z. Descending is 9-0 or Z-A.
         const currentPage = '2'; // Choose the number of search results to return per page. Minimum value: 1
         const pageSize = '30'; // Results per page. Allowed values 1-100, default is 25.

--- a/vod/delete-a-video.md
+++ b/vod/delete-a-video.md
@@ -1,24 +1,22 @@
 ---
 title: Delete a video
 meta:
-    description: This guide walks you through how to permanently remove a video programmatically, and through the dashboard.
+    description: This guide walks you through the different ways of manually and programmatically removing videos and introduces the Video Restore feature.
 ---
 
 # Delete A Video
 
-This guide walks you through how to permanently remove a video programmatically, and through the dashboard. Please be aware that you cannot retrieve a video you delete, so be sure it's what you want to do.
+This guide walks you through the different ways of manually and programmatically removing videos and introduces the Video Restore feature.
 
 ## API documentation
 
 - [Delete a video](/reference/api/Videos#delete-a-video-object)
 
-## Delete a video
+## Delete a video via API
 
-To delete a video, you need to do the following: 
+1. Retrieve the video ID for the video you want to delete. You can do this by [listing your videos](/reference/api/Videos#list-all-video-objects), or you can look in your dashboard to find the ID of the video you want to delete.
 
-1. Retrieve the video ID for the video you want to delete. You can do this by listing your videos and searching for the one you want, or you can look in your dashboard to find the video you want to delete. 
-
-2. Send a delete request to api.video containing the ID for the video you want to delete. Be sure you want to delete the video - there is no way to retrieve the content you delete. 
+2. Send a delete request to api.video containing the ID for the video you want to delete.
 
 <CodeSelect title="Deleting a video">
 ```curl
@@ -135,8 +133,45 @@ You can delete a video using your dashboard by doing the following:
 
    ![Showing the list of videos in the Dashboard](/_assets/vod/delete-video.png)
 
-4. Deleting videos is a permanent action and there is no way to recover them. Keep this in mind when you confirm deleting the videos.
+4. Keep in mind that deleted videos can only be restored when you have the Video Restore feature enabled. Otherwise videos are deleted permanently.
 
 5. You can also select the breadcrumbs icon next to each video to open an actions panel where you can select **Delete**.
 
    ![Showing the action panel on the videos list in the Dashboard](/_assets/vod/delete-video-2.png)
+
+
+## Restoring deleted videos
+
+By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
+
+If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it. 
+
+<Callout pad="2" type="info">
+Videos that are removed cannot be played. Restore the video first if you want to play it again.
+</Callout>
+
+You can restore removed videos both via the API and the dashboard.
+
+### Restore video via API
+
+You can use the `PATCH` operation to restore a video, with the `removed` body parameter set to `false`:
+
+```curl title="Restoring a video"
+curl --request PATCH \
+ --url https://ws.api.video/videos/viZxSTFgXZVjFnFCU \
+ --header 'Accept: application/json' \
+ --header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDI1NDk1NjAuMDE5ODA0LCJuYmYiOjE2NDI1NDk1NjAuMDE5ODA0LCJleHAiOjE2NDI1NTMxNjAuMDE5ODA0LCJwcm9qZWN0SWQiOiJwclJ6SUpKQTdCTHNxSGpTNDVLVnBCMSJ9.jjr4YADGbe62RmBBxJXLy1D61Mtfry_dq9nbriBXgkPrdlBJ8ZRP50CyW3AsGD7wSuKp2mXxEYSzj64zelT1IGOwg6KG4Gz9BZ9YWs0GAHKUIdgqn1gzITX5aQljIXx1fquXbawd-axBTi4icmaUjgXjfnyIcWOgHd2D8A3kpKiqiMmluh58JdnwPnH0OyVk0Rk824P0PI6SxfiTHfkCglPL6ixf9OgokMLPoVrsxH5C0xt3Z7lf5TJ0F78-JY-yTKvyaTTIfI6CFOMNaZUlMtgQwq8X93_2FA65Ntw3hdDML8gFKkLUxnBAtZMo9WAjUd30G4OcYasmlkc4Q_JSNw'
+ -d '{
+    "removed": false
+    }'  
+```
+
+### Restore video in the dashboard
+
+Visit the [Archived Videos](https://dashboard.api.video/videos) tab in the dashboard to restore videos one by one or in bulk. Simply select the videos you want to restore and then choose **Restore**.
+
+### Retention period for Video Restore
+
+The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted. This period gives you time to restore accidentally deleted videos.
+
+Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!

--- a/vod/delete-a-video.md
+++ b/vod/delete-a-video.md
@@ -144,27 +144,27 @@ You can delete a video using your dashboard by doing the following:
 
 By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
 
-If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it.
+If you have the Video Restore feature enabled, the `DELETE` operation will temporarily discard the video instead of permanently deleting it.
 
-You can restore removed videos both via the API and the dashboard.
+You can restore discarded videos both via the API and the dashboard.
 
-### Listing removed videos
+### Listing discarded videos
 
-You can list removed videos via the API using the `GET /videos` endpoint and the `?removed=true` query parameter. Visit the API reference for more details.
+You can list discarded videos via the API using the `GET /discarded/videos` endpoint for all videos, and the `GET /discarded/videos/{videoId}` for a specific video. Visit the API reference for more details.
 
-You can also see all your removed videos on the [Archived Videos](https://dashboard.api.video/videos) tab in the dashboard.
+You can also see all your discarded videos on the [Archived Videos](https://dashboard.api.video/videos) tab in the dashboard.
 
 ### Restoring video via API
 
-You can use the `PATCH` operation to restore a video, with the `removed` body parameter set to `false`:
+You can use the `PATCH /discarded/videos/{videoId}` operation to restore a video, with the `discarded` body parameter set to `false`:
 
 ```curl title="Restoring a video"
 curl --request PATCH \
- --url https://ws.api.video/videos/viZxSTFgXZVjFnFCU \
+ --url https://ws.api.video/discarded/videos/viZxSTFgXZVjFnFCU \
  --header 'Accept: application/json' \
  --header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDI1NDk1NjAuMDE5ODA0LCJuYmYiOjE2NDI1NDk1NjAuMDE5ODA0LCJleHAiOjE2NDI1NTMxNjAuMDE5ODA0LCJwcm9qZWN0SWQiOiJwclJ6SUpKQTdCTHNxSGpTNDVLVnBCMSJ9.jjr4YADGbe62RmBBxJXLy1D61Mtfry_dq9nbriBXgkPrdlBJ8ZRP50CyW3AsGD7wSuKp2mXxEYSzj64zelT1IGOwg6KG4Gz9BZ9YWs0GAHKUIdgqn1gzITX5aQljIXx1fquXbawd-axBTi4icmaUjgXjfnyIcWOgHd2D8A3kpKiqiMmluh58JdnwPnH0OyVk0Rk824P0PI6SxfiTHfkCglPL6ixf9OgokMLPoVrsxH5C0xt3Z7lf5TJ0F78-JY-yTKvyaTTIfI6CFOMNaZUlMtgQwq8X93_2FA65Ntw3hdDML8gFKkLUxnBAtZMo9WAjUd30G4OcYasmlkc4Q_JSNw'
  -d '{
-    "removed": false
+    "discarded": false
     }'  
 ```
 
@@ -174,14 +174,14 @@ Visit the [Archived Videos](https://dashboard.api.video/videos) tab in the dashb
 
 ### Retention period for Video Restore
 
-The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted. This period gives you time to restore accidentally deleted videos.
+The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted. This period gives you time to restore accidentally discarded videos.
 
 Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!
 
 ### Limitations
 
 <Callout pad="2" type="warning">
-Videos that are removed are not listed by the `GET /videos` operation unless you use the `?removed=true` query parameter.
+Videos that are discarded are not listed by the `GET /videos`or `GET /videos/{videoId}`operations.
 
-Removed videos cannot be played. Restore the video first if you want to play it again.
+Discarded videos cannot be played. Restore the video first if you want to play it again.
 </Callout>

--- a/vod/delete-a-video.md
+++ b/vod/delete-a-video.md
@@ -144,15 +144,17 @@ You can delete a video using your dashboard by doing the following:
 
 By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
 
-If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it. 
-
-<Callout pad="2" type="info">
-Videos that are removed cannot be played. Restore the video first if you want to play it again.
-</Callout>
+If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it.
 
 You can restore removed videos both via the API and the dashboard.
 
-### Restore video via API
+### Listing removed videos
+
+You can list removed videos via the API using the `GET /videos` endpoint and the `?removed=true` query parameter. Visit the API reference for more details.
+
+You can also see all your removed videos on the [Archived Videos](https://dashboard.api.video/videos) tab in the dashboard.
+
+### Restoring video via API
 
 You can use the `PATCH` operation to restore a video, with the `removed` body parameter set to `false`:
 
@@ -166,7 +168,7 @@ curl --request PATCH \
     }'  
 ```
 
-### Restore video in the dashboard
+### Restoring video in the dashboard
 
 Visit the [Archived Videos](https://dashboard.api.video/videos) tab in the dashboard to restore videos one by one or in bulk. Simply select the videos you want to restore and then choose **Restore**.
 
@@ -175,3 +177,11 @@ Visit the [Archived Videos](https://dashboard.api.video/videos) tab in the dashb
 The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted. This period gives you time to restore accidentally deleted videos.
 
 Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!
+
+### Limitations
+
+<Callout pad="2" type="warning">
+Videos that are removed are not listed by the `GET /videos` operation unless you use the `?removed=true` query parameter.
+
+Removed videos cannot be played. Restore the video first if you want to play it again.
+</Callout>

--- a/vod/video-best-practices.md
+++ b/vod/video-best-practices.md
@@ -97,10 +97,10 @@ In this case, the service will respond `202 Accepted` and ingest the video async
 
 By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
 
-* If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it. 
-* Videos that are removed are not listed by the `GET /videos` operation unless you use the `?removed=true` query parameter.
-* Videos that are removed cannot be played. Restore the video first if you want to play it again.
-* You can list and restore removed videos both via the API and the dashboard. Check out [this guide](/vod/delete-a-video#restoring-deleted-videos) for the details.
+* If you have the Video Restore feature enabled, the `DELETE` operation will temporarily discard the video instead of permanently deleting it. 
+* Videos that are discarded are not listed by the `GET /videos` or `GET /videos/{videoId}`operations.
+* Videos that are discarded cannot be played. Restore the video first if you want to play it again.
+* You can list and restore discarded videos both via the API and the dashboard. Check out [this guide](/vod/delete-a-video#restoring-deleted-videos) for the details.
 * The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted.
 
 Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!

--- a/vod/video-best-practices.md
+++ b/vod/video-best-practices.md
@@ -93,6 +93,17 @@ $ curl https://ws.api.video/videos \
 
 In this case, the service will respond `202 Accepted` and ingest the video asynchronously.
 
+## Restoring deleted videos
+
+By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
+
+* If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it. 
+* Videos that are removed cannot be played. Restore the video first if you want to play it again.
+* You can restore removed videos both via the API and the dashboard. Check out [this guide](/vod/delete-a-video) for the details.
+* The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted.
+
+Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!
+
 ## Resources
 
 Check out api.video's blog content and tutorials about:

--- a/vod/video-best-practices.md
+++ b/vod/video-best-practices.md
@@ -98,8 +98,9 @@ In this case, the service will respond `202 Accepted` and ingest the video async
 By default, deleting a video is a permanent action. To avoid accidents and enable you to restore deleted videos, api.video offers the [Video Restore](https://dashboard.api.video/account-settings/access) feature.
 
 * If you have the Video Restore feature enabled, the `DELETE` operation will temporarily remove the video instead of permanently deleting it. 
+* Videos that are removed are not listed by the `GET /videos` operation unless you use the `?removed=true` query parameter.
 * Videos that are removed cannot be played. Restore the video first if you want to play it again.
-* You can restore removed videos both via the API and the dashboard. Check out [this guide](/vod/delete-a-video) for the details.
+* You can list and restore removed videos both via the API and the dashboard. Check out [this guide](/vod/delete-a-video#restoring-deleted-videos) for the details.
 * The Video Restore feature retains videos for 90 days, after which the videos are permanently deleted.
 
 Visit the [dashboard](https://dashboard.api.video/account-settings/access) to enable this feature!


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1208125970959632).

**Summary**

* added information about the feature to the [Delete a video](https://docs.api.video/vod/delete-a-video) and [Video best practices](https://docs.api.video/vod/video-best-practices) guides.
* added some missing internal links to the API reference in the [Delete a video](https://docs.api.video/vod/delete-a-video) guide
* updated the API reference 👇 

**OpenAPI changes**

* added the new query parameter `removed` to `GET /videos` 
* added the new body parameter `removed` to `PATCH /videos/{videoId}`
* added new fields `deletesAt` and `removedAt` to the `video` response object
* updated the description of all date-time fields in the `video` response object to show ATOM format
* removed unnecessary mention of dynamic metadata from the description of the `video` response object