### PR TITLE
Add mention of the extended data retention for analytics

### DIFF
--- a/analytics/overview.md
+++ b/analytics/overview.md
@@ -23,7 +23,7 @@ Visit the **[Analytics](https://dashboard.api.video/analytics)** page on the Das
 
 Analytics uses player events to analyze and segment your viewers' interactions with your content. Here are some key aspects:
 
-- api.video retains analytics data for 30 days.
+- By default, api.video retains analytics data for 30 days. You can extend data retention to 3 months or 12 months through the [Analytics page in the Dashboard](https://dashboard.api.video/analytics) - click on the `3M` or `12M` buttons to get started!
 - Player events are generated when your viewers engage with a video or live stream session.
 - Data is refreshed in real time, with a frequency of `<5s`.
 - Data does not carry over from the previous versions of Analytics.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12733,7 +12733,7 @@ paths:
           Use this query parameter to define the starting date-time of the period you want analytics for.
 
           - If you do not set a value for `from`, the default assigned value is 1 day ago, based on the `to` parameter.
-          - The maximum value is 30 days ago.
+          - The maximum value is 30 days ago. You can extend data retention to 3 months or 12 months through the [Analytics page in the Dashboard](https://dashboard.api.video/analytics) - click on the `3M` or `12M` buttons to get started!
           - The value you provide should follow the ATOM date-time format: `2024-02-05T00:00:00+01:00`
           - The API ignores this parameter when you call `/data/metrics/play/total`.
         style: form
@@ -13006,7 +13006,7 @@ paths:
           Use this query parameter to define the starting date-time of the period you want analytics for.
 
           - If you do not set a value for `from`, the default assigned value is 1 day ago, based on the `to` parameter.
-          - The maximum value is 30 days ago.
+          - The maximum value is 30 days ago. You can extend data retention to 3 months or 12 months through the [Analytics page in the Dashboard](https://dashboard.api.video/analytics) - click on the `3M` or `12M` buttons to get started!
           - The value you provide should follow the ATOM date-time format: `2024-02-05T00:00:00+01:00`
         style: form
         explode: false
@@ -13302,7 +13302,7 @@ paths:
           Use this query parameter to define the starting date-time of the period you want analytics for.
 
           - If you do not set a value for `from`, the default assigned value is 1 day ago, based on the `to` parameter.
-          - The maximum value is 30 days ago.
+          - The maximum value is 30 days ago. You can extend data retention to 3 months or 12 months through the [Analytics page in the Dashboard](https://dashboard.api.video/analytics) - click on the `3M` or `12M` buttons to get started!
           - The value you provide should follow the ATOM date-time format: `2024-02-05T00:00:00+01:00`
         style: form
         explode: false


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1208318311784939).

**Summary**

- added mention of the Analytics addon that enables 3 months or 12 months of data retention
- updated both the Analytics guide and the API reference