### PR TITLE
Add missing tag

### DIFF
--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -39,6 +39,7 @@
         - Watermarks
         - Captions
         - Chapters
+        - Tags
 
 - heading: Live Streams
   items:

--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -8,24 +8,16 @@
     - label: Webhooks
       href: ./create-and-manage-webhooks.md
 
-- heading: Admin API
-  items:
-    - label: Overview
-      href: ././admin-api-overview.md
-    - open_api_spec: admin-api.yaml
-      only:
-        - Projects
-        - API keys
-        - Usage
-
 - heading: Authentication
   items:
     - label: Overview
       href: ./authentication-guide.md
-    - label: Basic authentication
-      href: ./basic-authentication.md
-    - label: Bearer token authentication
-      href: ./disposable-bearer-token-authentication.md
+      collapsed: true
+      items:
+        - label: Basic authentication
+          href: ./basic-authentication.md
+        - label: Bearer token authentication
+          href: ./disposable-bearer-token-authentication.md
     - open_api_spec: openapi.yaml
       only:
         - Advanced authentication
@@ -64,6 +56,16 @@
     - open_api_spec: openapi.yaml
       only:
         - Webhooks
+
+- heading: Admin API
+  items:
+    - label: Overview
+      href: ././admin-api-overview.md
+    - open_api_spec: admin-api.yaml
+      only:
+        - Projects
+        - API keys
+        - Usage
 
 - heading: Errors
   items:


### PR DESCRIPTION
Add missing OpenAPI tag for the `/tags` endpoint, so it is visible in the API reference's navigation sidebar.