### PR TITLE
Add summary guide and error docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1044,6 +1044,379 @@ paths:
                     type: 'https://docs.api.video/reference/too-many-requests'
                     title: Too many requests.
                     status: 429
+  /summaries:
+    post:
+      tags:
+        - Summaries
+      summary: Generate video summary
+      description: Generate a title, abstract, and key takeaways for a video.
+      x-client-action: create
+      x-client-description:
+        default: 'Generate a title, abstract, and key takeaways for a video.'
+      operationId: POST_summaries
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/summary-creation-payload'
+      responses:
+        '201':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/summary'
+              examples:
+                Summary created:
+                  value:
+                    summaryId: 'summary_1CGHWuXjhxmeH4WiZ51234'
+                    createdAt: '2024-07-14T23:36:07+00:00'
+                    updatedAt: '2024-07-14T23:36:07+00:00'
+                    videoId: 'vilkR8K3N7yrRcxcMt91234'
+                    origin: auto
+                    sourceStatus: completed
+        '409':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/conflict-error'
+              examples:
+                Summary already exists:
+                  value:
+                    type: https://docs.api.video/reference/summary-already-exists
+                    title: A summary already exists or is being created on this video.
+                    status: 409
+                    detail: You can delete the existing summary and generate a new one.
+                    name: videoId
+    get:
+      tags:
+      - Summaries
+      summary: List summaries
+      description: List all summarries for your videos in a project.
+      x-client-action: list
+      x-client-description:
+        default: 'List all summarries for your videos in a project.'
+      operationId: GET_summaries
+      parameters:
+        - name: videoId
+          in: query
+          required: false
+          description: Use this parameter to filter for a summary that belongs to a specific video.
+          schema:
+            type: string
+          example: vilkR8K3N7yrRcxcMt91234
+        - name: origin
+          in: query
+          required: false
+          description: 'Use this parameter to filter for summaries based on the way they were created: automatically or manually via the API.'
+          schema:
+            type: string
+            enum: [auto, api]
+          example: auto
+        - name: sourceStatus
+          in: query
+          required: false
+          description: |
+            Use this parameter to filter for summaries based on the current status of the summary source.
+            
+            These are the available statuses:
+            
+            `missing`: the input for a summary is not present.
+            `waiting` : the input video is being processed and a summary will be generated.
+            `failed`: a technical issue prevented summary generation.
+            `completed`: the summary is generated.
+            `unprocessable`: the API rules the source video to be unsuitable for summary generation. An example for this is an input video that has no audio.
+          schema:
+            type: string
+            enum: [missing, waiting, failed, completed, unprocessable]
+          example: auto
+        - name: sortBy
+          in: query
+          description: |
+            Use this parameter to choose which field the API will use to sort the response data. The default is `value`.
+            
+            These are the available fields to sort by:
+            
+            - `createdAt`: Sorts the results based on date and timestamps when summaries were created.
+            - `updatedAt`: Sorts the results based on date and timestamps when summaries were last updated.
+            - `videoId`: Sorts the results based on video IDs.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum: [createdAt, updatedAt, videoId]
+          example: createdAt
+        - name: sortOrder
+          in: query
+          description: 'Use this parameter to sort results. `asc` is ascending and sorts from A to Z. `desc` is descending and sorts from Z to A.'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum: [asc, desc]
+          example: asc
+        - $ref: '#/components/parameters/current-page'
+        - $ref: '#/components/parameters/page-size'
+      x-group-parameters: true
+      x-client-paginated: true
+      responses:
+        '200':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/summaries-list-response'
+              examples:
+                List all summaries:
+                  value:
+                    data:
+                    - summaryId: 'summary_1CGHWuXjhxmeH4WiZ51234'
+                      createdAt: '2024-07-14T23:36:07+00:00'
+                      updatedAt: '2024-07-14T23:36:07+00:00'
+                      videoId: 'vilkR8K3N7yrRcxcMt91234'
+                      origin: auto
+                      sourceStatus: completed
+                    - summaryId: 'summary_123HWuXjhxmeH4WiZ55678'
+                      createdAt: '2024-07-15T23:36:07+00:00'
+                      updatedAt: '2024-07-15T23:36:07+00:00'
+                      videoId: 'vibaBXK3N7yrRcxcMt95678'
+                      origin: auto
+                      sourceStatus: waiting     
+                    pagination:
+                      currentPage: 1
+                      pageSize: 25
+                      pagesTotal: 1
+                      itemsTotal: 11
+                      currentPageItems: 11
+                      links:
+                        - rel: self
+                          uri: 'https://ws.api.video/summaries?currentPage=1'
+                        - rel: first
+                          uri: 'https://ws.api.video/summaries?currentPage=1'
+                        - rel: last
+                          uri: 'https://ws.api.video/summaries?currentPage=1'
+  /summaries/{summaryId}:
+    delete:
+      tags:
+        - Summaries
+      summary: Delete video summary
+      description: Delete a summary tied to a video.
+      x-client-action: delete
+      x-client-description:
+        default: 'Delete a summary tied to a video.'
+      operationId: DELETE_summaries-summaryId
+      security:
+        - apiKey: []
+      parameters:
+        - name: summaryId
+          in: path
+          description: The unique identifier of the summary you want to delete.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: 'summary_1CGHWuXjhxmeH4WiZ51234'
+      responses:
+        '204':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: No Content      
+  /summaries/{summaryId}/source:
+    get:
+      tags:
+        - Summaries
+      summary: Get summary details
+      description: Get all details for a summary
+      x-client-action: getSummarySource
+      x-client-description:
+        default: 'Get all details for a summary.'
+      operationId: GET_summaries-summaryId-source
+      security:
+        - apiKey: []
+      parameters:
+        - name: summaryId
+          in: path
+          description: The unique identifier of the summary source you want to retrieve.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: 'summary_1CGHWuXjhxmeH4WiZ51234'
+      responses:
+        '200':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/summary-source'
+        '404':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/not-found'
+              examples:
+                response:
+                  value:
+                    type: 'https://docs.api.video/reference/resource-not-found'
+                    title: The requested resource was not found.
+                    name: summaryId
+                    status: 404
+    patch:
+      tags:
+        - Summaries
+      summary: Update summary details
+      description: Update details for a summary. Note that this operation is only allowed for summary objects where `sourceStatus` is `missing`.
+      x-client-action: update
+      x-client-description:
+        default: 'Update details for a summary. Note that this operation is only allowed for summary objects where `sourceStatus` is `missing`.'
+      operationId: PATCH_summaries-summaryId-source
+      parameters:
+        - name: summaryId
+          in: path
+          description: The unique identifier of the summary source you want to update.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+          example: 'summary_1CGHWuXjhxmeH4WiZ51234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/summary-update-payload'
+      responses:
+        '201':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/summary-source'
+        '409':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/conflict-error'
+              examples:
+                Summary already exists:
+                  value:
+                    type: https://docs.api.video/reference/summary-already-exists
+                    title: A summary already exists or is being created on this video.
+                    status: 409
+                    detail: You can delete the existing summary and generate a new one.
   '/videos/{videoId}/source':
     post:
       tags:
@@ -3366,6 +3739,33 @@ paths:
                     title: The requested resource was not found.
                     name: videoId
                     status: 404
+        '409':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/conflict-error'
+              examples:
+                Summary already exists:
+                  value:
+                    type: https://docs.api.video/reference/summary-already-exists
+                    title: A summary already exists or is being created on this video.
+                    status: 409
+                    detail: You can delete the existing summary and generate a new one.
+                    name: transcriptSummary
         '429':
           headers:
             X-RateLimit-Limit:
@@ -14646,12 +15046,16 @@ components:
       type: object
       properties:
         type:
+          description: A link to the error documentation.
           type: string
         title:
+          description: A description of the error that occurred.
           type: string
         name:
+          description: The name of the parameter that caused the error.
           type: string
         status:
+          description: The HTTP status code.
           type: integer
     too-many-requests:
       title: TooManyRequests
@@ -15465,8 +15869,151 @@ components:
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to transcribe the video. If you do not define a language, the API detects it based on the video. 
             - When the API generates a transcript, it will be available as a caption for the video.
+        transcriptSummary:
+          type: boolean
+          description: |-
+            Use this parameter to enable summarization. We recommend using this parameter together with `transcript: true`.
+            
+            - When `true`, the API generates a summary for the video, based on the transcription.
+            - The default value is `false`.
+            - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
       required:
         - title
+    summary-creation-payload:
+      required:
+        - videoId
+      type: object
+      properties:
+        videoId:
+          type: string
+          description: Create a summary of a video using the video ID.
+          example: vi4k0jvEUuaTdRAEjQ4Jfrgz
+        origin:
+          type: string
+          enum: [auto]
+          description: |-
+            Use this parameter to define how the API generates the summary. The only allowed value is `auto`, which means that the API generates a summary automatically.
+
+            If you do not set this parameter, **the API will not generate a summary automatically**.
+
+            In this case, `sourceStatus` will return `missing`, and you have to manually add a summary using the `PATCH /summaries/{summaryId}/source` endpoint operation.
+          example: auto
+    summary-update-payload:
+      type: object
+      properties:
+        title:
+          type: string
+          description: A video title, based on the contents of the video.
+          example: 'A short lecture on quantum theory'
+        abstract:
+          type: string
+          description: A short outline of the contents of the video.
+          example: 'In this lecture, we discuss how complicated quantum theory is, using the famous example of Schrödingers cat. We also discuss practical applications like quantum computing.'
+        takeaways:
+          type: array
+          description: A list of 3 key points from the video, in chronological order.
+          maxItems: 3
+          items:
+            type: string
+          example:
+          - Quantum theory is complicated.
+          - Schrödinger's cat is neither dead, nor alive.
+          - Quantum computers are super cool.
+    conflict-error:
+      type: object
+      properties:
+          type:
+            description: A link to the error documentation.
+            type: string
+          title:
+            description: A description of the error that occurred.
+            type: string
+          name:
+            description: The name of the parameter that caused the error.
+            type: string
+          status:
+            description: The HTTP status code.
+            type: integer
+          detail:
+            description:  A solution for the error.
+            type: string
+    summary-source:
+      type: object
+      properties:
+        title:
+          type: string
+          description: A video title, based on the contents of the video.
+          example: 'A short lecture on quantum theory'
+        abstract:
+          type: string
+          description: A short outline of the contents of the video. The length of an `abstract` depends on the amount of content in a video that can be transcribed. The API condenses the contents into minimum 20, maximum 300 words.
+          example: 'In this lecture, we discuss how complicated quantum theory is, using the famous example of Schrödingers cat. We also discuss practical applications like quantum computing.'
+        takeaways:
+          type: array
+          description: A list of 3 key points from the video, in chronological order.
+          maxItems: 3
+          items:
+            type: string
+          example:
+          - Quantum theory is complicated.
+          - Schrödinger's cat is neither dead, nor alive.
+          - Quantum computers are super cool.
+    summaries-list-response:
+      type: object
+      title: Summaries
+      properties:
+        data:
+          type: array
+          description: An array of summary objects.
+          items:
+            $ref: '#/components/schemas/summary'
+        pagination:
+          $ref: '#/components/schemas/pagination'
+      required:
+        - data
+        - pagination
+    summary:
+      type: object
+      properties:        
+        summaryId:
+          type: string
+          description: The unique identifier of the summary object.
+          example: 'summary_1CGHWuXjhxmeH4WiZ51234'
+        createdAt:
+          description: Returns the date and time when the summary was created in ATOM date-time format.
+          type: string
+          format: date-time
+          example: '2024-05-28T11:15:07+00:00'
+        updatedAt:
+          description: Returns the date and time when the summary was last updated in ATOM date-time format.
+          type: string
+          format: date-time
+          example: '2024-05-28T11:15:07+00:00'
+        videoId:
+          type: string
+          description: The unique identifier of the video object.
+          example: 'vi4k0jvEUuaTdRAEjQ4Prklg'
+        origin:
+          type: string
+          enum: 
+            - api
+            - auto
+          description:  |-
+            Returns the origin of how the summary was created.
+
+            - `api` means that no summary was generated automatically. You can add summary manually using the `PATCH /summaries/{summaryId}/source` endpoint operation. Until this happens, `sourceStatus` returns `missing`.
+            - `auto` means that the API generated the summary automatically.
+        sourceStatus:
+          type: string
+          description: |-
+            Returns the current status of summary generation.
+            
+            `missing`: the input for a summary is not present.
+            `waiting` : the input video is being processed and a summary will be generated.
+            `failed`: a technical issue prevented summary generation.
+            `completed`: the summary is generated.
+            `unprocessable`: the API rules the source video to be unsuitable for summary generation. An example for this is an input video that has no audio.
+          enum: [missing, waiting, failed, completed, unprocessable]
     video-upload-payload:
       required:
         - file
@@ -15564,6 +16111,14 @@ components:
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to transcribe the video. If you do not define a language, the API detects it based on the video. 
             - When the API generates a transcript, it will be available as a caption for the video.
+        transcriptSummary:
+          type: boolean
+          description: |-
+            Use this parameter to enable summarization. 
+            
+            - When `true`, the API generates a summary for the video, based on the transcription.
+            - The default value is `false`.
+            - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
       example:
         playerId: pl45KFKdlddgk654dspkze
         title: String theory
@@ -15571,6 +16126,7 @@ components:
         public: false
         language: 'en'
         transcript: true
+        transcriptSummary: true
         panoramic: false
         mp4Support: true
         tags:

--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -113,6 +113,8 @@
           href: ./unrecognized-request-url.md
         - label: Webhook Limit Reached
           href: ./webhook-limit-reached.md
+        - label: Summary Already Exists
+          href: ./summary-already-exists.md
     - label: Video Ingestion Errors
       href: ./video-upload-errors.md
       collapsed: true

--- a/reference/navigation.yaml
+++ b/reference/navigation.yaml
@@ -30,6 +30,7 @@
         - Videos
         - Watermarks
         - Captions
+        - Summaries
         - Chapters
         - Tags
 

--- a/reference/summary-already-exists.md
+++ b/reference/summary-already-exists.md
@@ -1,0 +1,47 @@
+---
+title: Summary already exists
+meta: 
+    description: This guide explains the cause and the possible solutions for the Summary already exists error.
+---
+
+# Summary already exists
+
+A summary already exists for the video that you tried adding a summary to.
+
+## Sample error response
+
+```json
+{
+  "type": "https://docs.api.video/reference/summary-already-exists",
+  "title": "A summary already exists or is being created on this video.",
+  "status": 409,
+  "detail": "You can delete the existing summary and generate a new one.",
+  "name": "videoId"
+}
+```
+
+## Causes
+
+This error can occur in 3 scenarios:
+
+- When using [`POST /summaries`](reference/api/Summaries#generate-video-summary) on an already uploaded video that has a summary, or where summary generation is in progress
+- When using [`PATCH /summaries/{summaryId}/source`](reference/api/Summaries#update-summary-details) on a video where a summary source is already generated, or where summary generation is in progress
+- When using [`PATCH /videos/{videoId}`](reference/api/Videos#update-a-video-object) on a video where a summary source is already generated, or where summary generation is in progress
+
+The API does not allow updating already generated summaries.
+
+## Solution
+
+To regenerate or fix an incorrect summary for a video, you first need to delete the existing summary:
+
+```curl
+curl -s --location --request DELETE 'https://ws.staging.api.video/summaries/summary_1CGHWuXjhxmeH4WiZ51234/source' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic {Your API key}' \
+```
+
+After the API responds with 204 - Deleted, you can repeat your original request to `POST` or `PATCH` the summary. 
+
+## Next steps
+
+- Learn more about the AI-driven [Summarization](/vod/create-summaries) feature

--- a/reference/summary-already-exists.md
+++ b/reference/summary-already-exists.md
@@ -24,9 +24,9 @@ A summary already exists for the video that you tried adding a summary to.
 
 This error can occur in 3 scenarios:
 
-- When using [`POST /summaries`](reference/api/Summaries#generate-video-summary) on an already uploaded video that has a summary, or where summary generation is in progress
-- When using [`PATCH /summaries/{summaryId}/source`](reference/api/Summaries#update-summary-details) on a video where a summary source is already generated, or where summary generation is in progress
-- When using [`PATCH /videos/{videoId}`](reference/api/Videos#update-a-video-object) on a video where a summary source is already generated, or where summary generation is in progress
+- When using [`POST /summaries`](/reference/api/Summaries#generate-video-summary) on an already uploaded video that has a summary, or where summary generation is in progress
+- When using [`PATCH /summaries/{summaryId}/source`](/reference/api/Summaries#update-summary-details) on a video where a summary source is already generated, or where summary generation is in progress
+- When using [`PATCH /videos/{videoId}`](/reference/api/Videos#update-a-video-object) on a video where a summary source is already generated, or where summary generation is in progress
 
 The API does not allow updating already generated summaries.
 

--- a/reference/summary-already-exists.md
+++ b/reference/summary-already-exists.md
@@ -40,7 +40,7 @@ curl -s --location --request DELETE 'https://ws.staging.api.video/summaries/summ
 --header 'Authorization: Basic {Your API key}' \
 ```
 
-After the API responds with 204 - Deleted, you can repeat your original request to `POST` or `PATCH` the summary. 
+After the API responds with `204 - Deleted`, you can repeat your original request to `POST` or `PATCH` the summary. 
 
 ## Next steps
 

--- a/reference/summary-already-exists.md
+++ b/reference/summary-already-exists.md
@@ -32,7 +32,7 @@ The API does not allow updating already generated summaries.
 
 ## Solution
 
-To regenerate or fix an incorrect summary for a video, you first need to delete the existing summary:
+To recreate or fix an incorrect summary for a video, you first need to delete the existing summary:
 
 ```curl
 curl -s --location --request DELETE 'https://ws.staging.api.video/summaries/summary_1CGHWuXjhxmeH4WiZ51234/source' \

--- a/vod/create-summaries.md
+++ b/vod/create-summaries.md
@@ -1,0 +1,151 @@
+---
+title: Create video summaries
+meta:
+  description: This page explains how to generate video summaries manually or automatically using the Videos and Summaries endpoints and the api.video dashboard.
+---
+
+# Create video summaries
+
+api.video's an AI-driven summarization feature can generate concise and accurate outlines of your videos. Each summary consist of a title, an abstract, and key takeaways based on the exact contents of a video. All of these are available directly in the player, on your dashboard, and through the API.
+
+Provide your audience with detailed descriptions and key points of your videos, and also enable more inclusive and accessible content by inviting deaf or hard-of-hearing users!
+
+<Callout pad="2" type="success">
+
+A summary is based on the transcription of a video. api.video uses [Whisper](https://openai.com/index/whisper/) for multilingual speech recognition and transcripton. We run Whisper's ASR models on our own infrastructure and do not expose data outside our service. You control who gets access to your videos and summaries.
+</Callout>
+
+## Summary data structure
+
+Summaries consist of 3 elements:
+
+- a **title** that clearly notes the topic of the video
+- an **abstract** that provides a short outline of the contents of the video
+- 3 **takeaways** in chronologial order, highlighting the key points of the video
+
+Each summary is identified by a `summaryId`. The API separates summary data into `summary` and `source` objects. A `summary` object contains information about the summary:
+
+```json
+{
+  "summaryId": "summary_1CGHWuXjhxmeH4WiZ51234",
+  "createdAt": "2024-07-14T23:36:07+00:00",
+  "updatedAt": "2024-07-14T23:36:07+00:00",
+  "videoId": "vilkR8K3N7yrRcxcMt91234",
+  "origin": "auto",
+  "sourceStatus": "completed"
+}
+```
+
+The `source` contains the actual title, abstract, and takeaways:
+
+```json
+{
+  "title": "A short lecture on quantum theory",
+  "abstract": "In this lecture, we discuss how complicated quantum theory is, using the famous example of Schrödingers cat. We also discuss practical applications like quantum computing.",
+  "takeaways": [
+    "Quantum theory is complicated.",
+    "Schrödinger's cat is neither dead, nor alive.",
+    "Quantum computers are super cool."
+  ]
+}
+```
+
+Visit the [API reference](/reference/api/Summaries) for detailed explanations of each field and attribute in the `summary` object.
+
+## How to create summaries
+
+You have 3 methods to create summaries. You can use:
+
+- the dashboard to enable summary generation during video upload, and for already uploaded videos
+- the `/videos` endpoint for automatic summarization via the API
+- the `/summaries` endpoint for more granular control on summary creation via the API
+
+This guide explains all 3 methods.
+
+### Generate summaries in the dashboard
+
+When you use the dashboard to [upload videos](https://dashboard.api.video/videos), simply switch on the **Summary** toggle during the upload process.
+
+<Callout pad="2" type="info">
+
+A summary is based on the transcription of a video. When you create summaries, we recommend that you also enable transcription. This enables our API to create video summaries faster.
+</Callout>
+
+For already updated videos, open the **Video Details** page and then the Summarization tab. Click on **Summarize** to generate a summary, or **Summarize again** to recreate a summary.
+
+### Automatic summarization
+
+When you use the API to upload videos, the easiest method to enable summary creation when you create a video object.
+
+To enable summarization, set the **optional** `transcriptSummary` parameter in your `POST` request to the [Create video object endpoint](/reference/api/Videos#create-a-video-object). We recommend that you also enable the **optional** `transcript` and `language` parameters. 
+
+When you define the video `language`, the API creates a summary of the video using the language you specify. Check out the list of supported languages [here](/vod/generate-transcripts#supported-languages). If you do not specify a language for the video, the API will detect it automatically.
+
+| Field               | Type      | Description                                                                                                                                                                                                                                                    |
+|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `transcriptSummary` | `boolean` | When `true`, the API generates a summary for the video. The default value is `false`.                                                                                                                                                                          |
+| `transcript`        | `boolean` | When `true`, the API generates a transcript for the video. The default value is `false`.                                                                                                                                                                       |
+| `language`          | `string`  | A valid language identifier using [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag). You can use primary subtags like `en` or `fr`.<br/><br/>When the value in your request does not match any covered language, the API returns an error. |
+
+You can also trigger automatic summarization for already uploaded videos. Use the same parameters in your `PATCH` request to the [Update video object endpoint](https://docs.api.video/reference/api/Videos#update-a-video-object).
+
+### Manual summarization
+
+This method enables you to control every step of the summary creation. We recommend that you use this method in scenarios where you want to manually create, update, or edit the generated summary.
+
+To summarize already uploaded videos manually, use a `POST` request to the [Summaries endpoint](/reference/api/Summaries). You have the option to define the origin of the summary generation with the `origin` request parameter.
+
+| Field    | Type     | Description                                                                                                                                                                |
+|----------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `origin` | `string` | Use this **optional** parameter to define how the API generates the summary. The only allowed value is `auto`, which means that the API generates a summary automatically. |
+
+
+<Callout pad="2" type="warning">
+
+If you do not set the `origin` parameter in your request, **the API will not generate a summary automatically**.
+
+In this case, `sourceStatus` will return `missing`, and you have to manually add the summary source using the `PATCH /summaries/{summaryId}/source` endpoint operation.
+</Callout>
+
+## Manage summaries
+
+The API provides dedicated endpoints to list, update, and delete summaries. You can use:
+
+- the `/summaries` endpoint to [`GET` a list of all summaries](/reference/api/Summaries#list-summaries) in your project, and to filter the list based on `videoId`, `origin`, or `sourceStatus`
+- the `/summaries/{summaryId}` endpoint to [`DELETE` a summary](/reference/api/Summaries#delete-video-summary)
+- the `/summaries/{summaryId}/source` endpoint to [`GET` the source of a specific summary](/reference/api/Summaries#get-summary-details), and to [`PATCH` an existing summary](/reference/api/Summaries#update-summary-details).
+
+## Summary generation statuses
+
+The `summary` object returns the status of summary generation in the `sourceStatus` field. These are the available statuses:
+            
+- `missing`: the source for a summary is not present.
+- `waiting` : the source video is being processed and a summary will be generated.
+- `failed`: a technical issue prevented summary generation.
+- `completed`: the summary is generated.
+- `unprocessable`: the source video is unsuitable for summary generation. An example for this is a source video that has no audio, or has less than 50 words.
+
+<Callout pad="2" type="info">
+
+Using the `PATCH /summaries/{summaryId}/source` endpoint operation is only allowed for summaries where `sourceStatus` is `missing`. The main purpose of this endpoint is to provide a direct way to edit or update summary sources.
+
+If you want to edit a summary where a source is already present, you first need to [delete the existing summary](/reference/api/Summaries#delete-video-summary).
+</Callout>
+
+## Supported languages
+
+The API creates summaries using the same language as for transcripts. Check out the [Generate transcripts guide](/vod/generate-transcripts#supported-languages) for the list of languages
+
+## Limitations
+
+<Callout pad="2" type="error">
+
+- The API requires at least 50 spoken words in the video you upload to create a transcript and a summary.
+- The length of a summary `abstract` is between 20 to 300 words. The exact length of the abstract depends on the contents of the video and will be roughly 1/8th of the transcript.
+- When you set the `language` parameter, make sure that it matches the actual language used in the video. Your setting forces the API to summarize in that language. Mismatching language settings or videos with dialogue in multiple languages can return low quality summaries.
+</Callout>
+
+## Next steps
+
+- Learn more about video transcription in the [Generate transcripts guide](/vod/generate-transcripts)
+- Check out other AI-driven features like video translation and AI summary [in our blog](https://api.video/blog/product-updates/ai-video-features/)

--- a/vod/generate-transcripts.md
+++ b/vod/generate-transcripts.md
@@ -4,7 +4,7 @@ meta:
   description: This page gets you started on how to enable automatic transcription for videos in multiple languages using the Videos endpoint.
 ---
 
-# Generating video transcripts
+# Generate video transcripts
 
 api.video's AI-driven transcription feature can generate video transcripts using a single API call. You can now avoid manually uploading captions, as the generated transcripts are available as video captions in the standard WebVTT format. 
 

--- a/vod/navigation.yaml
+++ b/vod/navigation.yaml
@@ -89,6 +89,8 @@
   items:
   - label: Transcripts
     href: /vod/generate-transcripts.md
+  - label: Summaries
+    href: /vod/create-summaries.md
   - label: Captions
     href: /vod/add-captions.md
   - label: Watermarks


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1208576035782993).

**Summary** 😏

- added the Create summaries guide that explains how summarization works, and how it can be used via the dashboard and the API
- added error documentation for the `Summary already exists` error
- updated grammar in the Transcription guide title


⚠️ **This PR should only be reviewed and should not be merged before release.**

Also note that I added the OpenAPI specification to this PR manually to be able to generate a staging build for reviews. The OpenAPI specification should be and probably will be overwritten by the **[this one](https://github.com/apivideo/api.video-api-client-generator/pull/399)** in the `client-generator` repo. cc. @olivierapivideo 