### PR TITLE
Add new webhooks

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14362,10 +14362,12 @@ paths:
       summary: Create Webhook
       description: |-
         Webhooks can push notifications to your server, rather than polling api.video for changes. We currently offer four events: 
-        * ```video.encoding.quality.completed``` Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ "type": "video.encoding.quality.completed", "emittedAt": "2021-01-29T16:46:25.217+01:00", "videoId": "viXXXXXXXX", "encoding": "hls", "quality": "720p"} ```. This request says that the 720p HLS encoding was completed.
-        * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-        * ```live-stream.broadcast.ended```  This event fires when a live stream has finished broadcasting.
-        * ```video.source.recorded```  This event occurs when a live stream is recorded and submitted for encoding.
+        * `video.encoding.quality.completed` Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ "type": "video.encoding.quality.completed", "emittedAt": "2021-01-29T16:46:25.217+01:00", "videoId": "viXXXXXXXX", "encoding": "hls", "quality": "720p"} ```. This request says that the 720p HLS encoding was completed.
+        * `live-stream.broadcast.started`  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
+        * `live-stream.broadcast.ended`  This event fires when a live stream has finished broadcasting.
+        * `video.source.recorded`  This event occurs when a live stream is recorded and submitted for encoding.
+        * `video.caption.generated`  This event occurs when an automatic caption has been generated.
+        * `video.summary.generated`  This event occurs when an automatic summary has been generated.
       operationId: POST-webhooks
       requestBody:
         required: true
@@ -15785,6 +15787,7 @@ components:
           example: '["video.encoding.quality.completed"]'
           items:
             type: string
+            enum: ['live-stream.broadcast.started', 'live-stream.broadcast.ended', 'video.source.recorded', 'video.encoding.quality.completed', 'video.caption.generated', 'video.summary.generated']
         url:
           type: string
           description: The URL where the API sends the webhook.
@@ -16885,15 +16888,12 @@ components:
         events:
           type: array
           description: |-
-            A list of the webhooks that you are subscribing to. There are Currently four webhook options:
-            * ```video.encoding.quality.completed```  Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ \"type\": \"video.encoding.quality.completed\", \"emittedAt\": \"2021-01-29T16:46:25.217+01:00\", \"videoId\": \"viXXXXXXXX\", \"encoding\": \"hls\", \"quality\": \"720p\"} ```. This request says that the 720p HLS encoding was completed.
-            * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-            * ```live-stream.broadcast.ended```  This event fires when a live stream has finished broadcasting.
-            * ```video.source.recorded```  Occurs when a live stream is recorded and submitted for encoding.
+            An array of webhook events that you want to subscribe to.
           example:
             - video.encoding.quality.completed
           items:
             type: string
+            enum: ['live-stream.broadcast.started', 'live-stream.broadcast.ended', 'video.source.recorded', 'video.encoding.quality.completed', 'video.caption.generated', 'video.summary.generated']
         url:
           type: string
           description: The the url to which HTTP notifications are sent. It could be any http or https URL.
@@ -17458,6 +17458,110 @@ x-webhooks:
                   type: string
                   enum: [240p, 360p, 480p, 720p, 1080p]
                   example: 1080p
+      responses:
+        '202':
+          summary: Accepted
+          description: Your webhook server may return this response to api.video to signal that the webhook is accepted.
+  video.caption.generated:
+    post:
+      tags:
+        - Webhooks
+      summary: Video caption generated
+      description: This webhook triggers when the API finishes generating a caption for a video.
+      operationId: POST-webhooks
+      parameters:
+        - in: header
+          name: X-Api-Video-WebhookID
+          schema:
+            type: string
+          description: The unique ID of your webhook.
+          required: true
+        - in: header
+          name: X-Api-Video-Signature
+          schema:
+            type: string
+          description: The webhook's body encrypted using the webhook's signature secret, in HMAC SHA256. Use this hash to verify that api.video is the origin of this webhook notification.
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: The name of the webhook event that occurred.
+                  example: video.caption.generated
+                emittedAt:
+                  description: Returns the date-time when the webhook event occurred.
+                  type: string
+                  format: date-time
+                  example: '2024-08-151T10:18:47+00:00'
+                videoId:
+                  description: The ID of the video where the caption was generated.
+                  type: string
+                  example: vi4blUQJFrYWbaG44NCh1234
+                captionId:
+                  description: The ID of the caption that was generated.
+                  type: string
+                  example: caption_1CHAfLFHT5B5EV4vzT1234
+                generationMode:
+                  description: Returns the method used to generate the caption. `transcript` means that the caption was generated based on the transcription of the video. Learn more about transcripts [here](https://docs.api.video/vod/generate-transcripts).
+                  type: string
+                  enum: [transcript]
+                  example: transcript
+                language:
+                  description: Returns the language of the captions in [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) format.
+                  example: en
+                  type: string
+                  enum: [ar, ca, cs, da, de, el, en, es, fa, fi, fr, he, hi, hr, hu, it, ja, ko, ml, nl, nn, no, pl, pt, ru, sk, sl, te, tr, uk, ur, vi, zh]
+      responses:
+        '202':
+          summary: Accepted
+          description: Your webhook server may return this response to api.video to signal that the webhook is accepted.
+  video.summary.generated:
+    post:
+      tags:
+        - Webhooks
+      summary: Video summary generated
+      description: This webhook triggers when the API finishes generating a summary for a video.
+      operationId: POST-webhooks
+      parameters:
+        - in: header
+          name: X-Api-Video-WebhookID
+          schema:
+            type: string
+          description: The unique ID of your webhook.
+          required: true
+        - in: header
+          name: X-Api-Video-Signature
+          schema:
+            type: string
+          description: The webhook's body encrypted using the webhook's signature secret, in HMAC SHA256. Use this hash to verify that api.video is the origin of this webhook notification.
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: The name of the webhook event that occurred.
+                  example: video.caption.generated
+                emittedAt:
+                  description: Returns the date-time when the webhook event occurred.
+                  type: string
+                  format: date-time
+                  example: '2024-08-151T10:18:47+00:00'
+                videoId:
+                  description: The ID of the video where the summary was generated.
+                  type: string
+                  example: vi4blUQJFrYWbaG44NCh1234
+                summaryId:
+                  description: The ID of the summary that was generated.
+                  type: string
+                  example: summary_1CGyYoB9XCgBk4iQna8ocT
       responses:
         '202':
           summary: Accepted


### PR DESCRIPTION
> Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1208756299627438).

**Summary**

- Added the new webhooks: `video.caption.generated` and `video.summary.generated`
- Updated the Create Webhook endpoint description, request schema, and response schema to list the webhook events as enums for the `events` field
- Added link to Transcript guide in the description for the `generationMode` attribute
> Created by @olivier-lando via https://github.com/apivideo/api.video-api-client-generator/pull/408